### PR TITLE
Add initial benchmark

### DIFF
--- a/benchmark/src/main/scala/io/travisbrown/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/travisbrown/benchmark/Benchmark.scala
@@ -1,0 +1,32 @@
+package io.travisbrown.benchmark
+
+import cats.std.all._
+import io.travisbrown.{ iteratee => i }
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import scalaz.{ iteratee => s }
+import scalaz.Scalaz._
+
+class ExampleData {
+  val maxSize = 200
+  val intsI: i.Enumerator[Int] = i.EnumeratorT.enumStream((0 to maxSize).toStream)
+  val intsS: s.Enumerator[Int] = s.EnumeratorT.enumStream((0 to maxSize).toStream)
+}
+
+/**
+ * Compare the performance of iteratee operations.
+ *
+ * The following command will run the benchmarks with reasonable settings:
+ *
+ * > sbt "benchmark/run -i 10 -wi 10 -f 2 -t 1 io.travisbrown.benchmark.IterateeBenchmark"
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class IterateeBenchmark extends ExampleData {
+  @Benchmark
+  def sumIntsI: Int = (i.IterateeT.sum[Int, cats.Id] &= intsI).run
+
+  @Benchmark
+  def sumIntsS: Int = (s.IterateeT.sum[Int, scalaz.Id.Id] &= intsS).run
+}

--- a/build.sbt
+++ b/build.sbt
@@ -92,6 +92,16 @@ lazy val coreBase = crossProject.in(file("core"))
 lazy val core = coreBase.jvm
 lazy val coreJS = coreBase.js
 
+lazy val benchmark = project
+  .settings(moduleName := "iteratee-benchmark")
+  .settings(allSettings)
+  .settings(noPublishSettings)
+  .settings(
+    libraryDependencies += "org.scalaz" %% "scalaz-iteratee" % "7.2.0-M3"
+  )
+  .enablePlugins(JmhPlugin)
+  .dependsOn(core)
+
 lazy val publishSettings = Seq(
   releaseCrossBuild := true,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,


### PR DESCRIPTION
This is a little surprising, since this project is still a pretty literal translation at the moment:

```
[info] Benchmark                    Mode  Cnt      Score     Error  Units
[info] IterateeBenchmark.sumIntsI  thrpt   40  47430.328 ± 677.958  ops/s
[info] IterateeBenchmark.sumIntsS  thrpt   40  39906.412 ± 481.330  ops/s
```

`I` indicates this project, `S` is Scalaz, and higher numbers are better. My guess is that this is largely due to the strictness of `combine`.