### PR TITLE
Add module system for convenience

### DIFF
--- a/benchmark/src/main/scala/io/iteratee/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/iteratee/benchmark/Benchmark.scala
@@ -16,7 +16,7 @@ class ExampleData {
   val intsS: s.EnumeratorT[Int, scalaz.Free.Trampoline] =
     s.EnumeratorT.enumList((0 to maxSize).toList)
 
-  val longsI: i.Enumerator[Long, cats.Eval] = i.Enumerator.iterate[Long, cats.Eval](_ + 1L, 0L)
+  val longsI: i.Enumerator[Long, cats.Eval] = i.Enumerator.iterate[Long, cats.Eval](0L)(_ + 1L)
   val longsS: s.EnumeratorT[Long, scalaz.Free.Trampoline] =
     s.EnumeratorT.iterate[Long, scalaz.Free.Trampoline](_ + 1L, 0L)
 }

--- a/core/shared/src/main/scala/io/iteratee/EnumerateeModule.scala
+++ b/core/shared/src/main/scala/io/iteratee/EnumerateeModule.scala
@@ -1,0 +1,43 @@
+package io.iteratee
+
+import algebra.Order
+import cats.Monad
+
+trait EnumerateeModule[F[_]] {
+  /**
+   * Applies a function to each input element and feeds the resulting outputs to the inner iteratee.
+   */
+  def map[O, I](f: O => I)(implicit F: Monad[F]): Enumeratee[O, I, F] = Enumeratee.map[O, I, F](f)
+
+  def flatMap[O, I](f: O => Enumerator[I, F])(implicit F: Monad[F]): Enumeratee[O, I, F] =
+    Enumeratee.flatMap[O, I, F](f)
+
+  def collect[O, I](pf: PartialFunction[O, I])(implicit F: Monad[F]): Enumeratee[O, I, F] =
+    Enumeratee.collect[O, I, F](pf)
+
+  def filter[E](p: E => Boolean)(implicit F: Monad[F]): Enumeratee[E, E, F] =
+    Enumeratee.filter[E, F](p)
+
+  def sequenceI[O, I](iteratee: Iteratee[O, F, I])(implicit F: Monad[F]): Enumeratee[O, I, F] =
+    Enumeratee.sequenceI[O, I, F](iteratee)
+
+  /**
+   * Uniqueness filter. Assumes that the input enumerator is already sorted.
+   */
+  def uniq[E: Order](implicit F: Monad[F]): Enumeratee[E, E, F] = Enumeratee.uniq[E, F]
+    
+  /**
+   * Zip with the count of elements that have been encountered.
+   */
+  def zipWithIndex[E](implicit F: Monad[F]): Enumeratee[E, (E, Long), F] =
+    Enumeratee.zipWithIndex[E, F]
+
+  def grouped[E](n: Int)(implicit F: Monad[F]): Enumeratee[E, Vector[E], F] =
+    Enumeratee.grouped[E, F](n)
+
+  def splitOn[E](p: E => Boolean)(implicit F: Monad[F]): Enumeratee[E, Vector[E], F] =
+    Enumeratee.splitOn[E, F](p)
+
+  def cross[E1, E2](e2: Enumerator[E2, F])(implicit F: Monad[F]): Enumeratee[E1, (E1, E2), F] =
+    Enumeratee.cross[E1, E2, F](e2)
+}

--- a/core/shared/src/main/scala/io/iteratee/Enumerator.scala
+++ b/core/shared/src/main/scala/io/iteratee/Enumerator.scala
@@ -236,7 +236,7 @@ object Enumerator extends EnumeratorInstances {
   /**
    * An enumerator that iteratively performs an operation.
    */
-  def iterate[E, F[_]: Monad](f: E => E, e: E): Enumerator[E, F] = new Enumerator[E, F] {
+  def iterate[E, F[_]: Monad](init: E)(f: E => E): Enumerator[E, F] = new Enumerator[E, F] {
     private[this] def loop[A](s: Step[E, F, A], last: E): Iteratee[E, F, A] = s.foldWith(
       new MapContStepFolder[E, F, A](s) {
         def onCont(k: Input[E] => Iteratee[E, F, A]): Iteratee[E, F, A] =
@@ -244,7 +244,7 @@ object Enumerator extends EnumeratorInstances {
       }
     )
 
-    def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] = loop(s, e)
+    def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] = loop(s, init)
   }
 }
 

--- a/core/shared/src/main/scala/io/iteratee/EnumeratorModule.scala
+++ b/core/shared/src/main/scala/io/iteratee/EnumeratorModule.scala
@@ -1,0 +1,54 @@
+package io.iteratee
+
+import cats.{ Applicative, Monad }
+
+trait EnumeratorModule[F[_]] {
+  def liftM[E](fe: F[E])(implicit F: Monad[F]): Enumerator[E, F] = Enumerator.liftM[F, E](fe)
+  def empty[E](implicit F: Applicative[F]): Enumerator[E, F] = Enumerator.empty[E, F]
+
+  /** 
+   * An Enumerator that is at EOF
+   */
+  def enumEnd[E](implicit F: Applicative[F]): Enumerator[E, F] = Enumerator.enumEnd[E, F]
+
+  /**
+   * An enumerator that forces the evaluation of an effect when it is consumed.
+   */
+  def perform[E, A](f: F[A])(implicit F: Monad[F]): Enumerator[E, F] =
+    Enumerator.perform[E, F, A](f)
+
+  /**
+   * An enumerator that produces a single value.
+   */
+  def enumOne[E](e: E)(implicit F: Applicative[F]): Enumerator[E, F] = Enumerator.enumOne[E, F](e)
+
+  /**
+   * An enumerator that produces values from a stream.
+   */
+  def enumStream[E](es: Stream[E])(implicit F: Monad[F]): Enumerator[E, F] =
+    Enumerator.enumStream[E, F](es)
+
+  /**
+   * An enumerator that produces values from a list.
+   */
+  def enumList[E](es: List[E])(implicit F: Monad[F]): Enumerator[E, F] =
+    Enumerator.enumList[E, F](es)
+
+  /**
+   * An enumerator that produces values from a slice of an indexed sequence.
+   */
+  def enumIndexedSeq[E](es: IndexedSeq[E], min: Int = 0, max: Int = Int.MaxValue)(implicit
+    F: Monad[F]
+  ): Enumerator[E, F] = Enumerator.enumIndexedSeq[E, F](es, min, max)
+
+  /**
+   * An enumerator that repeats a given value indefinitely.
+   */
+  def repeat[E](e: E)(implicit F: Monad[F]): Enumerator[E, F] = Enumerator.repeat[E, F](e)
+
+  /**
+   * An enumerator that iteratively performs an operation.
+   */
+  def iterate[E](init: E)(f: E => E)(implicit F: Monad[F]): Enumerator[E, F] =
+    Enumerator.iterate[E, F](init)(f)
+}

--- a/core/shared/src/main/scala/io/iteratee/IterateeModule.scala
+++ b/core/shared/src/main/scala/io/iteratee/IterateeModule.scala
@@ -1,0 +1,85 @@
+package io.iteratee
+
+import algebra.Monoid
+import cats.{ Applicative, Monad, MonoidK }
+
+trait IterateeModule[F[_]] {
+  /**
+   * Lift an effectful value into an iteratee.
+   */
+  def liftM[E, A](fa: F[A])(implicit F: Monad[F]): Iteratee[E, F, A] = Iteratee.liftM[E, F, A](fa)
+
+  def identity[E](implicit F: Applicative[F]): Iteratee[E, F, Unit] = Iteratee.identity[E, F]
+
+  /**
+   * An iteratee that consumes all of the input into something that is MonoidK and Applicative.
+   */
+  def consumeIn[E, A[_]: MonoidK: Applicative](implicit F: Monad[F]): Iteratee[E, F, A[E]] =
+    Iteratee.consumeIn[E, F, A]
+
+  def consume[E](implicit F: Monad[F]): Iteratee[E, F, Vector[E]] = Iteratee.consume[E, F]
+
+  def collectT[E, A[_]](implicit
+    M: Monad[F],
+    mae: Monoid[A[E]],
+    pointed: Applicative[A]
+  ): Iteratee[E, F, A[E]] = Iteratee.collectT[E, F, A]
+
+  /**
+   * An iteratee that consumes the head of the input.
+   */
+  def head[E](implicit F: Applicative[F]): Iteratee[E, F, Option[E]] = Iteratee.head[E, F]
+
+  /**
+   * An iteratee that returns the first element of the input.
+   */
+  def peek[E](implicit F: Applicative[F]): Iteratee[E, F, Option[E]] = Iteratee.peek[E, F]
+
+  /**
+   * Iteratee that collects all inputs in reverse with the given reducer.
+   *
+   * This iteratee is useful for `F[_]` with efficient cons, e.g. `List`.
+   */
+  def reversed[E](implicit F: Applicative[F]): Iteratee[E, F, List[E]] = Iteratee.reversed[E, F]
+
+  /**
+   * Iteratee that collects the first `n` inputs.
+   */
+  def take[E](n: Int)(implicit F: Applicative[F]): Iteratee[E, F, Vector[E]] =
+    Iteratee.take[E, F](n)
+
+  /**
+   * Iteratee that collects inputs until the input element fails a test.
+   */
+  def takeWhile[E](p: E => Boolean)(implicit F: Applicative[F]): Iteratee[E, F, Vector[E]] =
+    Iteratee.takeWhile[E, F](p)
+
+  /**
+   * An iteratee that skips the first `n` elements of the input.
+   */
+  def drop[E](n: Int)(implicit F: Applicative[F]): Iteratee[E, F, Unit] = Iteratee.drop[E, F](n)
+
+  /**
+   * An iteratee that skips elements while the predicate evaluates to true.
+   */
+  def dropWhile[E](p: E => Boolean)(implicit F: Applicative[F]): Iteratee[E, F, Unit] =
+    Iteratee.dropWhile[E, F](p)
+
+  def fold[E, A](init: A)(f: (A, E) => A)(implicit F: Applicative[F]): Iteratee[E, F, A] =
+    Iteratee.fold[E, F, A](init)(f)
+
+  def foldM[E, A](init: A)(f: (A, E) => F[A])(implicit F: Monad[F]): Iteratee[E, F, A] =
+    Iteratee.foldM[E, F, A](init)(f)
+
+  /**
+   * An iteratee that counts and consumes the elements of the input
+   */
+  def length[E](implicit F: Applicative[F]): Iteratee[E, F, Int] = Iteratee.length[E, F]
+
+  /**
+   * An iteratee that checks if the input is EOF.
+   */
+  def isEnd[E](implicit F: Applicative[F]): Iteratee[E, F, Boolean] = Iteratee.isEnd[E, F]
+
+  def sum[E: Monoid](implicit F: Monad[F]): Iteratee[E, F, E] = Iteratee.sum[E, F]
+}

--- a/core/shared/src/main/scala/io/iteratee/Module.scala
+++ b/core/shared/src/main/scala/io/iteratee/Module.scala
@@ -1,0 +1,3 @@
+package io.iteratee
+
+trait Module[F[_]] extends EnumerateeModule[F] with EnumeratorModule[F] with IterateeModule[F]

--- a/core/shared/src/main/scala/io/iteratee/package.scala
+++ b/core/shared/src/main/scala/io/iteratee/package.scala
@@ -1,10 +1,16 @@
 package io
 
-import cats.Id
+import cats.{ Eval, Id }
 
 package object iteratee {
   type PureStep[E, A] = Step[E, Id, A]
   type PureIteratee[E, A] = Iteratee[E, Id, A]
   type PureEnumerator[E] = Enumerator[E, Id]
   type PureEnumeratee[O, I] = Enumeratee[O, I, Id]
+}
+
+package iteratee {
+  object pure extends Module[Id]
+  object eval extends Module[Eval]
+  object option extends Module[Option]
 }

--- a/core/shared/src/test/scala/io/iteratee/EnumeratorSuite.scala
+++ b/core/shared/src/test/scala/io/iteratee/EnumeratorSuite.scala
@@ -205,7 +205,7 @@ class EnumeratorSuite extends FunSuite with Discipline
 
   test("iterate") {
     check { (i: Short, count: Short) =>
-      val enumerator = Enumerator.iterate[Int, Eval](_ + 1, i.toInt)
+      val enumerator = Enumerator.iterate[Int, Eval](i.toInt)(_ + 1)
       val result = Vector.iterate(i.toInt, count.toInt)(_ + 1)
 
       Iteratee.take[Int, Eval](count.toInt).feedE(enumerator).run.value === result


### PR DESCRIPTION
One minor API change (to `iterate`) and a new module setup that allows "partial application" of the type constructor for iteratees, etc.:

```scala
import io.iteratee.eval._

val it = take[String](2)
val en = enumList(List(1, 2, 3))
val f = map[Int, String](_.toString)
```

And then:

```scala
scala> it.feedE(f.wrap(en)).run
res5: cats.Eval[Vector[String]] = cats.Eval$$anon$8@3704996b
```

There's some repetition, but the convenience is worth it.