### PR TITLE
Make type constructor first type parameter

### DIFF
--- a/benchmark/src/main/scala/io/iteratee/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/iteratee/benchmark/Benchmark.scala
@@ -17,14 +17,14 @@ import scalaz.stream.Process
 class InMemoryExampleData {
   val size = 10000
   val intsC: Vector[Int] = (0 until size).toVector
-  val intsI: i.Enumerator[Int, Eval] = i.Enumerator.enumVector(intsC)
+  val intsI: i.Enumerator[Eval, Int] = i.Enumerator.enumVector(intsC)
   val intsS: Process[Task, Int] = Process.emitAll(intsC)
   val intsZ: z.EnumeratorT[Int, Trampoline] = z.EnumeratorT.enumIndexedSeq(intsC)
 }
 
 class StreamingExampleData {
   val longStreamC: Stream[Long] = Stream.iterate(0L)(_ + 1L)
-  val longStreamI: i.Enumerator[Long, Eval] = i.Enumerator.iterate[Long, Eval](0L)(_ + 1L)
+  val longStreamI: i.Enumerator[Eval, Long] = i.Enumerator.iterate[Eval, Long](0L)(_ + 1L)
   val longStreamS: Process[Task, Long] = Process.iterate(0L)(_ + 1L)
   val longStreamZ: z.EnumeratorT[Long, Trampoline] =
     z.EnumeratorT.iterate[Long, Trampoline](_ + 1L, 0L)
@@ -45,7 +45,7 @@ class InMemoryBenchmark extends InMemoryExampleData {
   def sumIntsC: Int = intsC.sum
 
   @Benchmark
-  def sumIntsI: Int = i.Iteratee.sum[Int, Eval].process(intsI).value
+  def sumIntsI: Int = i.Iteratee.sum[Eval, Int].process(intsI).value
 
   @Benchmark
   def sumIntsS: Int = intsS.sum.runLastOr(sys.error("Impossible")).run
@@ -71,7 +71,7 @@ class StreamingBenchmark extends StreamingExampleData {
   def takeLongsC: Vector[Long] = longStreamC.take(size).toVector
 
   @Benchmark
-  def takeLongsI: Vector[Long] = i.Iteratee.take[Long, Eval](size).process(longStreamI).value
+  def takeLongsI: Vector[Long] = i.Iteratee.take[Eval, Long](size).process(longStreamI).value
 
   @Benchmark
   def takeLongsS: Vector[Long] = longStreamS.take(size).runLog.run

--- a/core/shared/src/main/scala/io/iteratee/Enumeratee.scala
+++ b/core/shared/src/main/scala/io/iteratee/Enumeratee.scala
@@ -3,45 +3,45 @@ package io.iteratee
 import algebra.{ Monoid, Order }
 import cats.{ Applicative, Monad }
 
-abstract class Enumeratee[O, I, F[_]] extends Serializable { self =>
-  type Outer[A] = Iteratee[O, F, Step[I, F, A]]
+abstract class Enumeratee[F[_], O, I] extends Serializable { self =>
+  type Outer[A] = Iteratee[F, O, Step[F, I, A]]
 
-  def apply[A](step: Step[I, F, A]): Outer[A]
+  def apply[A](step: Step[F, I, A]): Outer[A]
 
-  final def wrap(enum: Enumerator[O, F])(implicit F: Monad[F]): Enumerator[I, F] =
-    new Enumerator[I, F] {
-      def apply[A](s: Step[I, F, A]): Iteratee[I, F, A] =
+  final def wrap(enum: Enumerator[F, O])(implicit F: Monad[F]): Enumerator[F, I] =
+    new Enumerator[F, I] {
+      def apply[A](s: Step[F, I, A]): Iteratee[F, I, A] =
         Iteratee.iteratee(self(s).process(enum))
     }
 
   /**
    * A convenience method that lets us lift a [[Step]] into a finished [[Iteratee]].
    */
-  protected final def toOuter[A](step: Step[I, F, A])(implicit F: Applicative[F]): Outer[A] =
-    Iteratee.done[O, F, Step[I, F, A]](step, Input.empty)
+  protected final def toOuter[A](step: Step[F, I, A])(implicit F: Applicative[F]): Outer[A] =
+    Iteratee.done[F, O, Step[F, I, A]](step, Input.empty)
 }
 
-abstract class LoopingEnumeratee[O, I, F[_]: Applicative] extends Enumeratee[O, I, F] {
-  protected def loop[A](k: Input[I] => Iteratee[I, F, A]): Outer[A]
+abstract class LoopingEnumeratee[F[_]: Applicative, O, I] extends Enumeratee[F, O, I] {
+  protected def loop[A](k: Input[I] => Iteratee[F, I, A]): Outer[A]
 
-  protected final def doneOrLoop[A](step: Step[I, F, A]): Outer[A] =
+  protected final def doneOrLoop[A](step: Step[F, I, A]): Outer[A] =
     step.foldWith(
-      new StepFolder[I, F, A, Outer[A]] {
-        def onCont(k: Input[I] => Iteratee[I, F, A]): Outer[A] = loop(k)
+      new StepFolder[F, I, A, Outer[A]] {
+        def onCont(k: Input[I] => Iteratee[F, I, A]): Outer[A] = loop(k)
         def onDone(value: A, remaining: Input[I]): Outer[A] = toOuter(step)
       }
     )
 
-  final def apply[A](step: Step[I, F, A]): Outer[A] = doneOrLoop[A](step)
+  final def apply[A](step: Step[F, I, A]): Outer[A] = doneOrLoop[A](step)
 }
 
-abstract class FolderEnumeratee[O, I, F[_]: Applicative] extends LoopingEnumeratee[O, I, F] {
-  protected def folder[A](k: Input[I] => Iteratee[I, F, A], in: Input[O]): InputFolder[O, Outer[A]]
+abstract class FolderEnumeratee[F[_]: Applicative, O, I] extends LoopingEnumeratee[F, O, I] {
+  protected def folder[A](k: Input[I] => Iteratee[F, I, A], in: Input[O]): InputFolder[O, Outer[A]]
 
-  protected final def loop[A](k: Input[I] => Iteratee[I, F, A]): Outer[A] =
-    Iteratee.cont[O, F, Step[I, F, A]](stepWith(k))
+  protected final def loop[A](k: Input[I] => Iteratee[F, I, A]): Outer[A] =
+    Iteratee.cont[F, O, Step[F, I, A]](stepWith(k))
 
-  protected final def stepWith[A](k: Input[I] => Iteratee[I, F, A]): Input[O] => Outer[A] =
+  protected final def stepWith[A](k: Input[I] => Iteratee[F, I, A]): Input[O] => Outer[A] =
     in => in.foldWith(folder[A](k, in))
 }
 
@@ -49,9 +49,9 @@ final object Enumeratee {
   /**
    * Applies a function to each input element and feeds the resulting outputs to the inner iteratee.
    */
-  final def map[O, I, F[_]: Monad](f: O => I): Enumeratee[O, I, F] =
-    new FolderEnumeratee[O, I, F] {
-      def folder[A](k: Input[I] => Iteratee[I, F, A], in: Input[O]): InputFolder[O, Outer[A]] =
+  final def map[F[_]: Monad, O, I](f: O => I): Enumeratee[F, O, I] =
+    new FolderEnumeratee[F, O, I] {
+      def folder[A](k: Input[I] => Iteratee[F, I, A], in: Input[O]): InputFolder[O, Outer[A]] =
         new InputFolder[O, Outer[A]] {
           def onEmpty: Outer[A] = Iteratee.cont(stepWith(k))
           def onEl(e: O): Outer[A] = k(Input.el(f(e))).advance(doneOrLoop)
@@ -60,20 +60,20 @@ final object Enumeratee {
         }
     }
 
-  final def flatMap[O, I, F[_]: Monad](f: O => Enumerator[I, F]): Enumeratee[O, I, F] =
-    new Enumeratee[O, I, F] {
-      private[this] lazy val monoid: Monoid[Enumerator[I, F]] = implicitly
+  final def flatMap[F[_]: Monad, O, I](f: O => Enumerator[F, I]): Enumeratee[F, O, I] =
+    new Enumeratee[F, O, I] {
+      private[this] lazy val monoid: Monoid[Enumerator[F, I]] = implicitly
 
-      private[this] def loop[A](step: Step[I, F, A]): Iteratee[O, F, Step[I, F, A]] =
+      private[this] def loop[A](step: Step[F, I, A]): Iteratee[F, O, Step[F, I, A]] =
         step.foldWith(
-          new StepFolder[I, F, A, Iteratee[O, F, Step[I, F, A]]] {
-            def onCont(k: Input[I] => Iteratee[I, F, A]): Outer[A] =
-              Iteratee.cont[O, F, Step[I, F, A]] {
+          new StepFolder[F, I, A, Iteratee[F, O, Step[F, I, A]]] {
+            def onCont(k: Input[I] => Iteratee[F, I, A]): Outer[A] =
+              Iteratee.cont[F, O, Step[F, I, A]] {
                 (_: Input[O]).map(e => f(e)).foldWith(
-                  new InputFolder[Enumerator[I, F], Outer[A]] {
+                  new InputFolder[Enumerator[F, I], Outer[A]] {
                     def onEmpty: Outer[A] = k(Input.empty).advance(loop)
-                    def onEl(e: Enumerator[I, F]): Outer[A] = e(step).advance(loop)
-                    def onChunk(es: Vector[Enumerator[I, F]]): Outer[A] =
+                    def onEl(e: Enumerator[F, I]): Outer[A] = e(step).advance(loop)
+                    def onChunk(es: Vector[Enumerator[F, I]]): Outer[A] =
                       monoid.combineAll(es).apply(step).advance(loop)
                     def onEnd: Outer[A] = toOuter(step)
                   }
@@ -84,12 +84,12 @@ final object Enumeratee {
           }
         )
 
-      def apply[A](step: Step[I, F, A]): Iteratee[O, F, Step[I, F, A]] = loop(step)
+      def apply[A](step: Step[F, I, A]): Iteratee[F, O, Step[F, I, A]] = loop(step)
     }
 
-  final def collect[O, I, F[_]: Monad](pf: PartialFunction[O, I]): Enumeratee[O, I, F] =
-    new FolderEnumeratee[O, I, F] {
-      def folder[A](k: Input[I] => Iteratee[I, F, A], in: Input[O]): InputFolder[O, Outer[A]] =
+  final def collect[F[_]: Monad, O, I](pf: PartialFunction[O, I]): Enumeratee[F, O, I] =
+    new FolderEnumeratee[F, O, I] {
+      def folder[A](k: Input[I] => Iteratee[F, I, A], in: Input[O]): InputFolder[O, Outer[A]] =
         new InputFolder[O, Outer[A]] {
           def onEmpty: Outer[A] = Iteratee.cont(stepWith(k))
           def onEl(e: O): Outer[A] =
@@ -102,9 +102,9 @@ final object Enumeratee {
         }
     }
 
-  final def filter[E, F[_]: Monad](p: E => Boolean): Enumeratee[E, E, F] =
-    new FolderEnumeratee[E, E, F] {
-      def folder[A](k: Input[E] => Iteratee[E, F, A], in: Input[E]): InputFolder[E, Outer[A]] =
+  final def filter[F[_]: Monad, E](p: E => Boolean): Enumeratee[F, E, E] =
+    new FolderEnumeratee[F, E, E] {
+      def folder[A](k: Input[E] => Iteratee[F, E, A], in: Input[E]): InputFolder[E, Outer[A]] =
         new InputFolder[E, Outer[A]] {
           def onEmpty: Outer[A] = Iteratee.cont(stepWith(k))
           def onEl(e: E): Outer[A] =
@@ -114,49 +114,49 @@ final object Enumeratee {
         }
     }
 
-  final def sequenceI[O, I, F[_]: Monad](iteratee: Iteratee[O, F, I]): Enumeratee[O, I, F] =
-    new LoopingEnumeratee[O, I, F] {
-      protected def loop[A](k: Input[I] => Iteratee[I, F, A]): Outer[A] =
-        Iteratee.isEnd[O, F].flatMap { isEnd =>
+  final def sequenceI[F[_]: Monad, O, I](iteratee: Iteratee[F, O, I]): Enumeratee[F, O, I] =
+    new LoopingEnumeratee[F, O, I] {
+      protected def loop[A](k: Input[I] => Iteratee[F, I, A]): Outer[A] =
+        Iteratee.isEnd[F, O].flatMap { isEnd =>
           if (isEnd) Iteratee.done(Step.cont(k), Input.end) else stepWith(k)
         }
 
       private[this] def stepWith[A](
-        k: Input[I] => Iteratee[I, F, A]
+        k: Input[I] => Iteratee[F, I, A]
       ): Outer[A] = iteratee.flatMap(a => k(Input.el(a)).advance(doneOrLoop))
     }
 
   /**
    * Uniqueness filter. Assumes that the input enumerator is already sorted.
    */
-  final def uniq[E: Order, F[_]: Monad]: Enumeratee[E, E, F] =
-    new Enumeratee[E, E, F] {
-      private[this] def stepWith[A](step: Step[E, F, A], last: Input[E]): Iteratee[E, F, A] =
+  final def uniq[F[_]: Monad, E: Order]: Enumeratee[F, E, E] =
+    new Enumeratee[F, E, E] {
+      private[this] def stepWith[A](step: Step[F, E, A], last: Input[E]): Iteratee[F, E, A] =
         step.foldWith(
-          new StepFolder[E, F, A, Iteratee[E, F, A]] {
-            def onCont(k: Input[E] => Iteratee[E, F, A]): Iteratee[E, F, A] = Iteratee.cont { in =>
+          new StepFolder[F, E, A, Iteratee[F, E, A]] {
+            def onCont(k: Input[E] => Iteratee[F, E, A]): Iteratee[F, E, A] = Iteratee.cont { in =>
               val inr = in.filter(e => last.forall(l => Order[E].neqv(e, l)))
               k(inr).advance(stepWith(_, in))
             }
-            def onDone(value: A, remainder: Input[E]): Iteratee[E, F, A] = step.pointI
+            def onDone(value: A, remainder: Input[E]): Iteratee[F, E, A] = step.pointI
           }
         )
 
-      def apply[A](step: Step[E, F, A]): Outer[A] =
+      def apply[A](step: Step[F, E, A]): Outer[A] =
         stepWith(step, Input.empty).map(Step.done(_, Input.empty))
     }
     
   /**
    * Zip with the count of elements that have been encountered.
    */
-  final def zipWithIndex[E, F[_]: Monad]: Enumeratee[E, (E, Long), F] =
-    new Enumeratee[E, (E, Long), F] {
-      type StepEl[A] = Input[(E, Long)] => Iteratee[(E, Long), F, A]
+  final def zipWithIndex[F[_]: Monad, E]: Enumeratee[F, E, (E, Long)] =
+    new Enumeratee[F, E, (E, Long)] {
+      type StepEl[A] = Input[(E, Long)] => Iteratee[F, (E, Long), A]
 
-      private[this] final def doneOrLoop[A](i: Long)(step: Step[(E, Long), F, A]): Outer[A] =
+      private[this] final def doneOrLoop[A](i: Long)(step: Step[F, (E, Long), A]): Outer[A] =
         step.foldWith(
-          new StepFolder[(E, Long), F, A, Outer[A]] {
-            def onCont(k: Input[(E, Long)] => Iteratee[(E, Long), F, A]): Outer[A] = loop(i, k)
+          new StepFolder[F, (E, Long), A, Outer[A]] {
+            def onCont(k: Input[(E, Long)] => Iteratee[F, (E, Long), A]): Outer[A] = loop(i, k)
             def onDone(value: A, remaining: Input[(E, Long)]): Outer[A] = toOuter(step)
           }
         )
@@ -177,30 +177,30 @@ final object Enumeratee {
           }
         )
 
-      final def apply[A](step: Step[(E, Long), F, A]): Outer[A] = doneOrLoop(0)(step)
+      final def apply[A](step: Step[F, (E, Long), A]): Outer[A] = doneOrLoop(0)(step)
     }
 
-  final def grouped[E, F[_]: Monad](n: Int): Enumeratee[E, Vector[E], F] =
-    sequenceI(Iteratee.take[E, F](n))
+  final def grouped[F[_]: Monad, E](n: Int): Enumeratee[F, E, Vector[E]] =
+    sequenceI(Iteratee.take[F, E](n))
 
-  final def splitOn[E, F[_]: Monad](p: E => Boolean): Enumeratee[E, Vector[E], F] = sequenceI(
-    Iteratee.takeWhile[E, F](e => !p(e)).flatMap(es => Iteratee.drop(1).map(_ => es))
+  final def splitOn[F[_]: Monad, E](p: E => Boolean): Enumeratee[F, E, Vector[E]] = sequenceI(
+    Iteratee.takeWhile[F, E](e => !p(e)).flatMap(es => Iteratee.drop(1).map(_ => es))
   )
 
-  final def cross[E1, E2, F[_]: Monad](e2: Enumerator[E2, F]): Enumeratee[E1, (E1, E2), F] =
-    new Enumeratee[E1, (E1, E2), F] {
+  final def cross[F[_]: Monad, E1, E2](e2: Enumerator[F, E2]): Enumeratee[F, E1, (E1, E2)] =
+    new Enumeratee[F, E1, (E1, E2)] {
       private[this] def outerLoop[A](
-        step: Step[(E1, E2), F, A]
+        step: Step[F, (E1, E2), A]
       ): Outer[A] =
-        Iteratee.head[E1, F].flatMap {
+        Iteratee.head[F, E1].flatMap {
           case Some(e) => 
-            val pairingIteratee = Enumeratee.map[E2, (E1, E2), F]((e, _)).apply(step)
+            val pairingIteratee = Enumeratee.map[F, E2, (E1, E2)]((e, _)).apply(step)
             val nextStep = pairingIteratee.process(e2)
             Iteratee.iteratee(nextStep).advance(outerLoop)
 
           case None => Iteratee.done(step, Input.end[E1])
         }
 
-      def apply[A](step: Step[(E1, E2), F, A]): Outer[A] = outerLoop(step)
+      def apply[A](step: Step[F, (E1, E2), A]): Outer[A] = outerLoop(step)
     }
 }

--- a/core/shared/src/main/scala/io/iteratee/EnumerateeModule.scala
+++ b/core/shared/src/main/scala/io/iteratee/EnumerateeModule.scala
@@ -7,42 +7,42 @@ trait EnumerateeModule[F[_]] {
   /**
    * Applies a function to each input element and feeds the resulting outputs to the inner iteratee.
    */
-  final def map[O, I](f: O => I)(implicit F: Monad[F]): Enumeratee[O, I, F] =
-    Enumeratee.map[O, I, F](f)
+  final def map[O, I](f: O => I)(implicit F: Monad[F]): Enumeratee[F, O, I] =
+    Enumeratee.map[F, O, I](f)
 
-  final def flatMap[O, I](f: O => Enumerator[I, F])(implicit F: Monad[F]): Enumeratee[O, I, F] =
-    Enumeratee.flatMap[O, I, F](f)
+  final def flatMap[O, I](f: O => Enumerator[F, I])(implicit F: Monad[F]): Enumeratee[F, O, I] =
+    Enumeratee.flatMap[F, O, I](f)
 
-  final def collect[O, I](pf: PartialFunction[O, I])(implicit F: Monad[F]): Enumeratee[O, I, F] =
-    Enumeratee.collect[O, I, F](pf)
+  final def collect[O, I](pf: PartialFunction[O, I])(implicit F: Monad[F]): Enumeratee[F, O, I] =
+    Enumeratee.collect[F, O, I](pf)
 
-  final def filter[E](p: E => Boolean)(implicit F: Monad[F]): Enumeratee[E, E, F] =
-    Enumeratee.filter[E, F](p)
+  final def filter[E](p: E => Boolean)(implicit F: Monad[F]): Enumeratee[F, E, E] =
+    Enumeratee.filter[F, E](p)
 
-  final def sequenceI[O, I](iteratee: Iteratee[O, F, I])(implicit
+  final def sequenceI[O, I](iteratee: Iteratee[F, O, I])(implicit
     F: Monad[F]
-  ): Enumeratee[O, I, F] =
-    Enumeratee.sequenceI[O, I, F](iteratee)
+  ): Enumeratee[F, O, I] =
+    Enumeratee.sequenceI[F, O, I](iteratee)
 
   /**
    * Uniqueness filter. Assumes that the input enumerator is already sorted.
    */
-  final def uniq[E: Order](implicit F: Monad[F]): Enumeratee[E, E, F] = Enumeratee.uniq[E, F]
+  final def uniq[E: Order](implicit F: Monad[F]): Enumeratee[F, E, E] = Enumeratee.uniq[F, E]
     
   /**
    * Zip with the count of elements that have been encountered.
    */
-  final def zipWithIndex[E](implicit F: Monad[F]): Enumeratee[E, (E, Long), F] =
-    Enumeratee.zipWithIndex[E, F]
+  final def zipWithIndex[E](implicit F: Monad[F]): Enumeratee[F, E, (E, Long)] =
+    Enumeratee.zipWithIndex[F, E]
 
-  final def grouped[E](n: Int)(implicit F: Monad[F]): Enumeratee[E, Vector[E], F] =
-    Enumeratee.grouped[E, F](n)
+  final def grouped[E](n: Int)(implicit F: Monad[F]): Enumeratee[F, E, Vector[E]] =
+    Enumeratee.grouped[F, E](n)
 
-  final def splitOn[E](p: E => Boolean)(implicit F: Monad[F]): Enumeratee[E, Vector[E], F] =
-    Enumeratee.splitOn[E, F](p)
+  final def splitOn[E](p: E => Boolean)(implicit F: Monad[F]): Enumeratee[F, E, Vector[E]] =
+    Enumeratee.splitOn[F, E](p)
 
-  final def cross[E1, E2](e2: Enumerator[E2, F])(implicit
+  final def cross[E1, E2](e2: Enumerator[F, E2])(implicit
     F: Monad[F]
-  ): Enumeratee[E1, (E1, E2), F] =
-    Enumeratee.cross[E1, E2, F](e2)
+  ): Enumeratee[F, E1, (E1, E2)] =
+    Enumeratee.cross[F, E1, E2](e2)
 }

--- a/core/shared/src/main/scala/io/iteratee/Enumerator.scala
+++ b/core/shared/src/main/scala/io/iteratee/Enumerator.scala
@@ -3,117 +3,117 @@ package io.iteratee
 import algebra.{ Monoid, Order, Semigroup }
 import cats.{ Applicative, FlatMap, Functor, Id, Monad, MonoidK }
 
-abstract class Enumerator[E, F[_]] extends Serializable { self =>
-  def apply[A](s: Step[E, F, A]): Iteratee[E, F, A]
+abstract class Enumerator[F[_], E] extends Serializable { self =>
+  def apply[A](s: Step[F, E, A]): Iteratee[F, E, A]
 
-  final def mapE[I](enumeratee: Enumeratee[E, I, F])(implicit M: Monad[F]): Enumerator[I, F] =
+  final def mapE[I](enumeratee: Enumeratee[F, E, I])(implicit M: Monad[F]): Enumerator[F, I] =
     enumeratee.wrap(self)
 
-  final def map[B](f: E => B)(implicit ev: Monad[F]): Enumerator[B, F] =
-    Enumeratee.map[E, B, F](f).wrap(self)
+  final def map[B](f: E => B)(implicit ev: Monad[F]): Enumerator[F, B] =
+    Enumeratee.map[F, E, B](f).wrap(self)
 
-  final def #::(e: => E)(implicit F: Monad[F]): Enumerator[E, F] = {
-    new Enumerator[E, F] {
-      def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] =
+  final def #::(e: => E)(implicit F: Monad[F]): Enumerator[F, E] = {
+    new Enumerator[F, E] {
+      def apply[A](s: Step[F, E, A]): Iteratee[F, E, A] =
         s.foldWith(
-          new StepFolder[E, F, A, Iteratee[E, F, A]] {
-            def onCont(k: Input[E] => Iteratee[E, F, A]): Iteratee[E, F, A] = k(Input.el(e))
-            def onDone(value: A, remaining: Input[E]): Iteratee[E, F, A] = s.pointI
+          new StepFolder[F, E, A, Iteratee[F, E, A]] {
+            def onCont(k: Input[E] => Iteratee[F, E, A]): Iteratee[F, E, A] = k(Input.el(e))
+            def onDone(value: A, remaining: Input[E]): Iteratee[F, E, A] = s.pointI
           }
         ).feed(self)
     }
   }
 
-  final def append(e2: Enumerator[E, F])(implicit F: FlatMap[F]): Enumerator[E, F] =
-    new Enumerator[E, F] {
-      final def apply[A](step: Step[E, F, A]): Iteratee[E, F, A] = self(step).feed(e2)
+  final def append(e2: Enumerator[F, E])(implicit F: FlatMap[F]): Enumerator[F, E] =
+    new Enumerator[F, E] {
+      final def apply[A](step: Step[F, E, A]): Iteratee[F, E, A] = self(step).feed(e2)
     }
 
-  final def flatMap[B](f: E => Enumerator[B, F])(implicit M1: Monad[F]) =
+  final def flatMap[B](f: E => Enumerator[F, B])(implicit M1: Monad[F]) =
     Enumeratee.flatMap(f).wrap(self)
 
-  final def flatten[B](implicit ev: E =:= F[B], M: Monad[F]): Enumerator[B, F] =
+  final def flatten[B](implicit ev: E =:= F[B], M: Monad[F]): Enumerator[F, B] =
     flatMap(e => Enumerator.liftM[F, B](ev(e)))
 
-  final def bindM[B, G[_]](f: E => G[Enumerator[B, F]])(implicit
+  final def bindM[B, G[_]](f: E => G[Enumerator[F, B]])(implicit
     F: Monad[F],
     G: Monad[G]
-  ): F[G[Enumerator[B, F]]] = {
-    val iteratee = Iteratee.fold[G[Enumerator[B, F]], F, G[Enumerator[B, F]]](
-      G.pure(Enumerator.empty[B, F])
+  ): F[G[Enumerator[F, B]]] = {
+    val iteratee = Iteratee.fold[F, G[Enumerator[F, B]], G[Enumerator[F, B]]](
+      G.pure(Enumerator.empty[F, B])
     ) {
       case (acc, concat) => G.flatMap(acc) { en =>
-        G.map(concat) { append => Semigroup[Enumerator[B, F]].combine(en, append) }
+        G.map(concat) { append => Semigroup[Enumerator[F, B]].combine(en, append) }
       }
     }   
 
     iteratee.feed(self.map(f)).run
   }
 
-  final def collect[B](pf: PartialFunction[E, B])(implicit F: Monad[F]): Enumerator[B, F] =
-    Enumeratee.collect[E, B, F](pf).wrap(self)
+  final def collect[B](pf: PartialFunction[E, B])(implicit F: Monad[F]): Enumerator[F, B] =
+    Enumeratee.collect[F, E, B](pf).wrap(self)
 
-  final def filter(p: E => Boolean)(implicit F: Monad[F]): Enumerator[E, F] =
-    Enumeratee.filter[E, F](p).wrap(self)
+  final def filter(p: E => Boolean)(implicit F: Monad[F]): Enumerator[F, E] =
+    Enumeratee.filter[F, E](p).wrap(self)
 
-  final def uniq(implicit ord: Order[E], F: Monad[F]): Enumerator[E, F] =
-    Enumeratee.uniq[E, F].wrap(self)
+  final def uniq(implicit ord: Order[E], F: Monad[F]): Enumerator[F, E] =
+    Enumeratee.uniq[F, E].wrap(self)
 
-  final def zipWithIndex(implicit F: Monad[F]): Enumerator[(E, Long), F] =
-    Enumeratee.zipWithIndex[E, F].wrap(self)
+  final def zipWithIndex(implicit F: Monad[F]): Enumerator[F, (E, Long)] =
+    Enumeratee.zipWithIndex[F, E].wrap(self)
 
-  final def grouped(n: Int)(implicit F: Monad[F]): Enumerator[Vector[E], F] =
-    Enumeratee.grouped[E, F](n).wrap(self)
+  final def grouped(n: Int)(implicit F: Monad[F]): Enumerator[F, Vector[E]] =
+    Enumeratee.grouped[F, E](n).wrap(self)
 
-  final def splitOn(p: E => Boolean)(implicit F: Monad[F]): Enumerator[Vector[E], F] =
-    Enumeratee.splitOn[E, F](p).wrap(self)
+  final def splitOn(p: E => Boolean)(implicit F: Monad[F]): Enumerator[F, Vector[E]] =
+    Enumeratee.splitOn[F, E](p).wrap(self)
 
-  final def drain(implicit F: Monad[F]): F[Vector[E]] = Iteratee.consume[E, F].process(self)
+  final def drain(implicit F: Monad[F]): F[Vector[E]] = Iteratee.consume[F, E].process(self)
 
   final def drainTo[M[_]](implicit M: Monad[F], P: MonoidK[M], Z: Applicative[M]): F[M[E]] =
-    Iteratee.consumeIn[E, F, M].process(self)
+    Iteratee.consumeIn[F, E, M].process(self)
 
-  final def reduced[B](b: B)(f: (B, E) => B)(implicit M: Monad[F]): Enumerator[B, F] =
-    new Enumerator[B, F] {
-      final def apply[A](step: Step[B, F, A]): Iteratee[B, F, A] = {
-        def check(s: Step[E, F, B]): Iteratee[B, F, A] = s.foldWith(
-          new StepFolder[E, F, B, Iteratee[B, F, A]] {
-            def onCont(k: Input[E] => Iteratee[E, F, B]): Iteratee[B, F, A] = k(Input.end).advance {
+  final def reduced[B](b: B)(f: (B, E) => B)(implicit M: Monad[F]): Enumerator[F, B] =
+    new Enumerator[F, B] {
+      final def apply[A](step: Step[F, B, A]): Iteratee[F, B, A] = {
+        def check(s: Step[F, E, B]): Iteratee[F, B, A] = s.foldWith(
+          new StepFolder[F, E, B, Iteratee[F, B, A]] {
+            def onCont(k: Input[E] => Iteratee[F, E, B]): Iteratee[F, B, A] = k(Input.end).advance {
               s => s.foldWith(
-                new StepFolder[E, F, B, Iteratee[B, F, A]] {
-                  def onCont(k: Input[E] => Iteratee[E, F, B]): Iteratee[B, F, A] = Iteratee.diverge
-                  def onDone(value: B, remainder: Input[E]): Iteratee[B, F, A] = check(s)
+                new StepFolder[F, E, B, Iteratee[F, B, A]] {
+                  def onCont(k: Input[E] => Iteratee[F, E, B]): Iteratee[F, B, A] = Iteratee.diverge
+                  def onDone(value: B, remainder: Input[E]): Iteratee[F, B, A] = check(s)
                 }
               )
             }
-            def onDone(value: B, remainder: Input[E]): Iteratee[B, F, A] = step.foldWith(
-              new MapContStepFolder[B, F, A](step) {
-                def onCont(k: Input[B] => Iteratee[B, F, A]): Iteratee[B, F, A] = k(Input.el(value))
+            def onDone(value: B, remainder: Input[E]): Iteratee[F, B, A] = step.foldWith(
+              new MapContStepFolder[F, B, A](step) {
+                def onCont(k: Input[B] => Iteratee[F, B, A]): Iteratee[F, B, A] = k(Input.el(value))
               }
             )
           }
         )
 
         Iteratee.iteratee(
-          M.flatMap(Iteratee.fold[E, F, B](b)(f).feed(self).step)(check(_).step)
+          M.flatMap(Iteratee.fold[F, E, B](b)(f).feed(self).step)(check(_).step)
         )
       }
     }
     
-  final def cross[E2](e2: Enumerator[E2, F])(implicit M: Monad[F]): Enumerator[(E, E2), F] =
-    Enumeratee.cross[E, E2, F](e2).wrap(self)
+  final def cross[E2](e2: Enumerator[F, E2])(implicit M: Monad[F]): Enumerator[F, (E, E2)] =
+    Enumeratee.cross[F, E, E2](e2).wrap(self)
 }
 
 trait EnumeratorInstances {
-  implicit final def EnumeratorMonoid[E, F[_]: Monad]: Monoid[Enumerator[E, F]] =
-    new Monoid[Enumerator[E, F]] {
-      def combine(e1: Enumerator[E, F], e2: Enumerator[E, F]): Enumerator[E, F] = e1.append(e2)
-      def empty: Enumerator[E, F] = Enumerator.empty[E, F]
+  implicit final def EnumeratorMonoid[F[_]: Monad, E]: Monoid[Enumerator[F, E]] =
+    new Monoid[Enumerator[F, E]] {
+      def combine(e1: Enumerator[F, E], e2: Enumerator[F, E]): Enumerator[F, E] = e1.append(e2)
+      def empty: Enumerator[F, E] = Enumerator.empty[F, E]
     }
 
   implicit final def EnumeratorMonad[F[_]](implicit
     M0: Monad[F]
-  ): Monad[({ type L[x] = Enumerator[x, F] })#L] =
+  ): Monad[({ type L[x] = Enumerator[F, x] })#L] =
     new EnumeratorMonad[F] {
       implicit val M: Monad[F] = M0
     }
@@ -122,34 +122,32 @@ trait EnumeratorInstances {
 final object Enumerator extends EnumeratorInstances {
   private[this] final val defaultChunkSize: Int = 1024
 
-  final def liftM[F[_], E](fa: F[E])(implicit F: Monad[F]): Enumerator[E, F] =
-    new Enumerator[E, F] {
-      def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] = Iteratee.iteratee(
+  final def liftM[F[_], E](fa: F[E])(implicit F: Monad[F]): Enumerator[F, E] =
+    new Enumerator[F, E] {
+      def apply[A](s: Step[F, E, A]): Iteratee[F, E, A] = Iteratee.iteratee(
         F.flatMap(fa) { e =>
           s.foldWith(
-            new MapContStepFolder[E, F, A](s) {
-              def onCont(k: Input[E] => Iteratee[E, F, A]): Iteratee[E, F, A] = k(Input.el(e))
+            new MapContStepFolder[F, E, A](s) {
+              def onCont(k: Input[E] => Iteratee[F, E, A]): Iteratee[F, E, A] = k(Input.el(e))
             }
           ).step
         }
       )
     }
 
-  final def enumerate[E](as: Stream[E]): PureEnumerator[E] = enumStream[E, Id](as)
-
-  final def empty[E, F[_]: Applicative]: Enumerator[E, F] =
-    new Enumerator[E, F] {
-      def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] = s.pointI
+  final def empty[F[_]: Applicative, E]: Enumerator[F, E] =
+    new Enumerator[F, E] {
+      def apply[A](s: Step[F, E, A]): Iteratee[F, E, A] = s.pointI
     }
 
   /** 
    * An enumerator that is at EOF.
    */
-  final def enumEnd[E, F[_]: Applicative]: Enumerator[E, F] =
-    new Enumerator[E, F] {
-      def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] = s.foldWith(
-        new MapContStepFolder[E, F, A](s) {
-          def onCont(k: Input[E] => Iteratee[E, F, A]): Iteratee[E, F, A] = k(Input.end)
+  final def enumEnd[F[_]: Applicative, E]: Enumerator[F, E] =
+    new Enumerator[F, E] {
+      def apply[A](s: Step[F, E, A]): Iteratee[F, E, A] = s.foldWith(
+        new MapContStepFolder[F, E, A](s) {
+          def onCont(k: Input[E] => Iteratee[F, E, A]): Iteratee[F, E, A] = k(Input.end)
         }
       )
     }
@@ -157,30 +155,30 @@ final object Enumerator extends EnumeratorInstances {
   /**
    * An enumerator that forces the evaluation of an effect when it is consumed.
    */
-  final def perform[E, F[_], B](f: F[B])(implicit F: Monad[F]): Enumerator[E, F] =
-    new Enumerator[E, F] {
-      def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] =
+  final def perform[F[_], E, B](f: F[B])(implicit F: Monad[F]): Enumerator[F, E] =
+    new Enumerator[F, E] {
+      def apply[A](s: Step[F, E, A]): Iteratee[F, E, A] =
         Iteratee.iteratee(F.flatMap(f)(_ => F.pure(s)))
     }
 
   /**
    * An enumerator that produces a single value.
    */
-  final def enumOne[E, F[_]: Applicative](e: E): Enumerator[E, F] = new Enumerator[E, F] {
-    def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] = s.foldWith(
-      new MapContStepFolder[E, F, A](s) {
-        def onCont(k: Input[E] => Iteratee[E, F, A]): Iteratee[E, F, A] = k(Input.el(e))
+  final def enumOne[F[_]: Applicative, E](e: E): Enumerator[F, E] = new Enumerator[F, E] {
+    def apply[A](s: Step[F, E, A]): Iteratee[F, E, A] = s.foldWith(
+      new MapContStepFolder[F, E, A](s) {
+        def onCont(k: Input[E] => Iteratee[F, E, A]): Iteratee[F, E, A] = k(Input.el(e))
       }
     )
   }
 
-  private[this] abstract class ChunkedIteratorEnumerator[E, F[_]: Monad] extends Enumerator[E, F] {
+  private[this] abstract class ChunkedIteratorEnumerator[F[_]: Monad, E] extends Enumerator[F, E] {
     def chunks: Iterator[Vector[E]]
 
-    private[this] final def go[A](it: Iterator[Vector[E]], s: Step[E, F, A]): Iteratee[E, F, A] =
+    private[this] final def go[A](it: Iterator[Vector[E]], s: Step[F, E, A]): Iteratee[F, E, A] =
       if (it.isEmpty) s.pointI else s.foldWith(
-        new MapContStepFolder[E, F, A](s) {
-          def onCont(k: Input[E] => Iteratee[E, F, A]): Iteratee[E, F, A] = {
+        new MapContStepFolder[F, E, A](s) {
+          def onCont(k: Input[E] => Iteratee[F, E, A]): Iteratee[F, E, A] = {
             val next = it.next()
 
             k(Input.chunk(next)).advance(go(it, _))
@@ -188,27 +186,27 @@ final object Enumerator extends EnumeratorInstances {
         }
       )
 
-    final def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] = go(chunks, s)
+    final def apply[A](s: Step[F, E, A]): Iteratee[F, E, A] = go(chunks, s)
   }
 
   /**
    * An enumerator that produces values from a stream.
    */
-  final def enumStream[E, F[_]: Monad](
+  final def enumStream[F[_]: Monad, E](
     xs: Stream[E],
     chunkSize: Int = defaultChunkSize
-  ): Enumerator[E, F] = new ChunkedIteratorEnumerator[E, F] {
+  ): Enumerator[F, E] = new ChunkedIteratorEnumerator[F, E] {
     def chunks: Iterator[Vector[E]] = xs.grouped(chunkSize).map(_.toVector)
   }
 
   /**
    * An enumerator that produces values from a list.
    */
-  final def enumList[E, F[_]: Monad](xs: List[E]): Enumerator[E, F] = new Enumerator[E, F] {
-    def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] =
+  final def enumList[F[_]: Monad, E](xs: List[E]): Enumerator[F, E] = new Enumerator[F, E] {
+    def apply[A](s: Step[F, E, A]): Iteratee[F, E, A] =
       if (xs.isEmpty) s.pointI else s.foldWith(
-        new MapContStepFolder[E, F, A](s) {
-          def onCont(k: Input[E] => Iteratee[E, F, A]): Iteratee[E, F, A] =
+        new MapContStepFolder[F, E, A](s) {
+          def onCont(k: Input[E] => Iteratee[F, E, A]): Iteratee[F, E, A] =
             k(Input.chunk(xs.toVector))
         }
       )
@@ -217,11 +215,11 @@ final object Enumerator extends EnumeratorInstances {
   /**
    * An enumerator that produces values from a vector.
    */
-  final def enumVector[E, F[_]: Monad](xs: Vector[E]): Enumerator[E, F] = new Enumerator[E, F] {
-    def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] =
+  final def enumVector[F[_]: Monad, E](xs: Vector[E]): Enumerator[F, E] = new Enumerator[F, E] {
+    def apply[A](s: Step[F, E, A]): Iteratee[F, E, A] =
       if (xs.isEmpty) s.pointI else s.foldWith(
-        new MapContStepFolder[E, F, A](s) {
-          def onCont(k: Input[E] => Iteratee[E, F, A]): Iteratee[E, F, A] = k(Input.chunk(xs))
+        new MapContStepFolder[F, E, A](s) {
+          def onCont(k: Input[E] => Iteratee[F, E, A]): Iteratee[F, E, A] = k(Input.chunk(xs))
         }
       )
   }
@@ -229,31 +227,31 @@ final object Enumerator extends EnumeratorInstances {
   /**
    * An enumerator that produces values from a slice of an indexed sequence.
    */
-  final def enumIndexedSeq[E, F[_]: Monad](
+  final def enumIndexedSeq[F[_]: Monad, E](
     xs: IndexedSeq[E],
     min: Int = 0,
     max: Int = Int.MaxValue
-  ): Enumerator[E, F] = new Enumerator[E, F] {
+  ): Enumerator[F, E] = new Enumerator[F, E] {
     private val limit = math.min(xs.length, max)
 
-    private[this] def loop[A](pos: Int)(s: Step[E, F, A]): Iteratee[E, F, A] = s.foldWith(
-      new MapContStepFolder[E, F, A](s) {
-        def onCont(k: Input[E] => Iteratee[E, F, A]): Iteratee[E, F, A] =
+    private[this] def loop[A](pos: Int)(s: Step[F, E, A]): Iteratee[F, E, A] = s.foldWith(
+      new MapContStepFolder[F, E, A](s) {
+        def onCont(k: Input[E] => Iteratee[F, E, A]): Iteratee[F, E, A] =
           if (limit > pos) k(Input.el(xs(pos))).advance(loop(pos + 1)) else s.pointI
       }
     )
 
 
-    def apply[A](step: Step[E, F, A]): Iteratee[E, F, A] = loop(min)(step)
+    def apply[A](step: Step[F, E, A]): Iteratee[F, E, A] = loop(min)(step)
   }
 
   /**
    * An enumerator that repeats a given value indefinitely.
    */
-  final def repeat[E, F[_]: Monad](e: E): Enumerator[E, F] = new Enumerator[E, F] {
-    def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] = s.foldWith(
-      new MapContStepFolder[E, F, A](s) {
-        def onCont(k: Input[E] => Iteratee[E, F, A]): Iteratee[E, F, A] =
+  final def repeat[F[_]: Monad, E](e: E): Enumerator[F, E] = new Enumerator[F, E] {
+    def apply[A](s: Step[F, E, A]): Iteratee[F, E, A] = s.foldWith(
+      new MapContStepFolder[F, E, A](s) {
+        def onCont(k: Input[E] => Iteratee[F, E, A]): Iteratee[F, E, A] =
           k(Input.el(e)).advance(apply[A])
       }
     )
@@ -262,26 +260,26 @@ final object Enumerator extends EnumeratorInstances {
   /**
    * An enumerator that iteratively performs an operation.
    */
-  final def iterate[E, F[_]: Monad](init: E)(f: E => E): Enumerator[E, F] = new Enumerator[E, F] {
-    private[this] def loop[A](s: Step[E, F, A], last: E): Iteratee[E, F, A] = s.foldWith(
-      new MapContStepFolder[E, F, A](s) {
-        def onCont(k: Input[E] => Iteratee[E, F, A]): Iteratee[E, F, A] =
+  final def iterate[F[_]: Monad, E](init: E)(f: E => E): Enumerator[F, E] = new Enumerator[F, E] {
+    private[this] def loop[A](s: Step[F, E, A], last: E): Iteratee[F, E, A] = s.foldWith(
+      new MapContStepFolder[F, E, A](s) {
+        def onCont(k: Input[E] => Iteratee[F, E, A]): Iteratee[F, E, A] =
           k(Input.el(last)).advance(step => loop(step, f(last)))
       }
     )
 
-    def apply[A](s: Step[E, F, A]): Iteratee[E, F, A] = loop(s, init)
+    def apply[A](s: Step[F, E, A]): Iteratee[F, E, A] = loop(s, init)
   }
 }
 
-private trait EnumeratorFunctor[F[_]] extends Functor[({ type L[x] = Enumerator[x, F] })#L] {
+private trait EnumeratorFunctor[F[_]] extends Functor[({ type L[x] = Enumerator[F, x] })#L] {
   implicit def M: Monad[F]
-  abstract override def map[A, B](fa: Enumerator[A, F])(f: A => B): Enumerator[B, F] = fa.map(f)
+  abstract override def map[A, B](fa: Enumerator[F, A])(f: A => B): Enumerator[F, B] = fa.map(f)
 }
 
-private trait EnumeratorMonad[F[_]] extends Monad[({ type L[x] = Enumerator[x, F] })#L]
+private trait EnumeratorMonad[F[_]] extends Monad[({ type L[x] = Enumerator[F, x] })#L]
   with EnumeratorFunctor[F] {
-  final def flatMap[A, B](fa: Enumerator[A, F])(f: A => Enumerator[B, F]): Enumerator[B, F] =
+  final def flatMap[A, B](fa: Enumerator[F, A])(f: A => Enumerator[F, B]): Enumerator[F, B] =
     fa.flatMap(f)
-  final def pure[E](e: E): Enumerator[E, F] = Enumerator.enumOne[E, F](e)
+  final def pure[E](e: E): Enumerator[F, E] = Enumerator.enumOne[F, E](e)
 }

--- a/core/shared/src/main/scala/io/iteratee/EnumeratorModule.scala
+++ b/core/shared/src/main/scala/io/iteratee/EnumeratorModule.scala
@@ -6,61 +6,61 @@ trait EnumeratorModule[F[_]] {
   /**
    * Lift an effectful value into an enumerator.
    */
-  final def liftToEnumerator[E](fe: F[E])(implicit F: Monad[F]): Enumerator[E, F] =
+  final def liftToEnumerator[E](fe: F[E])(implicit F: Monad[F]): Enumerator[F, E] =
     Enumerator.liftM[F, E](fe)
 
-  final def empty[E](implicit F: Applicative[F]): Enumerator[E, F] = Enumerator.empty[E, F]
+  final def empty[E](implicit F: Applicative[F]): Enumerator[F, E] = Enumerator.empty[F, E]
 
   /** 
    * An enumerator that is at EOF.
    */
-  final def enumEnd[E](implicit F: Applicative[F]): Enumerator[E, F] = Enumerator.enumEnd[E, F]
+  final def enumEnd[E](implicit F: Applicative[F]): Enumerator[F, E] = Enumerator.enumEnd[F, E]
 
   /**
    * An enumerator that forces the evaluation of an effect when it is consumed.
    */
-  final def perform[E, A](f: F[A])(implicit F: Monad[F]): Enumerator[E, F] =
-    Enumerator.perform[E, F, A](f)
+  final def perform[E, A](f: F[A])(implicit F: Monad[F]): Enumerator[F, E] =
+    Enumerator.perform[F, E, A](f)
 
   /**
    * An enumerator that produces a single value.
    */
-  final def enumOne[E](e: E)(implicit F: Applicative[F]): Enumerator[E, F] =
-    Enumerator.enumOne[E, F](e)
+  final def enumOne[E](e: E)(implicit F: Applicative[F]): Enumerator[F, E] =
+    Enumerator.enumOne[F, E](e)
 
   /**
    * An enumerator that produces values from a stream.
    */
-  final def enumStream[E](es: Stream[E])(implicit F: Monad[F]): Enumerator[E, F] =
-    Enumerator.enumStream[E, F](es)
+  final def enumStream[E](es: Stream[E])(implicit F: Monad[F]): Enumerator[F, E] =
+    Enumerator.enumStream[F, E](es)
 
   /**
    * An enumerator that produces values from a list.
    */
-  final def enumList[E](es: List[E])(implicit F: Monad[F]): Enumerator[E, F] =
-    Enumerator.enumList[E, F](es)
+  final def enumList[E](es: List[E])(implicit F: Monad[F]): Enumerator[F, E] =
+    Enumerator.enumList[F, E](es)
 
   /**
    * An enumerator that produces values from a vector.
    */
-  final def enumVector[E](es: Vector[E])(implicit F: Monad[F]): Enumerator[E, F] =
-    Enumerator.enumVector[E, F](es)
+  final def enumVector[E](es: Vector[E])(implicit F: Monad[F]): Enumerator[F, E] =
+    Enumerator.enumVector[F, E](es)
 
   /**
    * An enumerator that produces values from a slice of an indexed sequence.
    */
   final def enumIndexedSeq[E](es: IndexedSeq[E], min: Int = 0, max: Int = Int.MaxValue)(implicit
     F: Monad[F]
-  ): Enumerator[E, F] = Enumerator.enumIndexedSeq[E, F](es, min, max)
+  ): Enumerator[F, E] = Enumerator.enumIndexedSeq[F, E](es, min, max)
 
   /**
    * An enumerator that repeats a given value indefinitely.
    */
-  final def repeat[E](e: E)(implicit F: Monad[F]): Enumerator[E, F] = Enumerator.repeat[E, F](e)
+  final def repeat[E](e: E)(implicit F: Monad[F]): Enumerator[F, E] = Enumerator.repeat[F, E](e)
 
   /**
    * An enumerator that iteratively performs an operation.
    */
-  final def iterate[E](init: E)(f: E => E)(implicit F: Monad[F]): Enumerator[E, F] =
-    Enumerator.iterate[E, F](init)(f)
+  final def iterate[E](init: E)(f: E => E)(implicit F: Monad[F]): Enumerator[F, E] =
+    Enumerator.iterate[F, E](init)(f)
 }

--- a/core/shared/src/main/scala/io/iteratee/IterateeModule.scala
+++ b/core/shared/src/main/scala/io/iteratee/IterateeModule.scala
@@ -7,80 +7,80 @@ trait IterateeModule[F[_]] {
   /**
    * Lift an effectful value into an iteratee.
    */
-  final def liftToIteratee[E, A](fa: F[A])(implicit F: Monad[F]): Iteratee[E, F, A] =
-    Iteratee.liftM[E, F, A](fa)
+  final def liftToIteratee[E, A](fa: F[A])(implicit F: Monad[F]): Iteratee[F, E, A] =
+    Iteratee.liftM[F, E, A](fa)
 
-  final def identity[E](implicit F: Applicative[F]): Iteratee[E, F, Unit] = Iteratee.identity[E, F]
+  final def identity[E](implicit F: Applicative[F]): Iteratee[F, E, Unit] = Iteratee.identity[F, E]
 
   /**
    * An iteratee that consumes all of the input into something that is MonoidK and Applicative.
    */
-  final def consumeIn[E, A[_]: MonoidK: Applicative](implicit F: Monad[F]): Iteratee[E, F, A[E]] =
-    Iteratee.consumeIn[E, F, A]
+  final def consumeIn[E, A[_]: MonoidK: Applicative](implicit F: Monad[F]): Iteratee[F, E, A[E]] =
+    Iteratee.consumeIn[F, E, A]
 
-  final def consume[E](implicit F: Monad[F]): Iteratee[E, F, Vector[E]] = Iteratee.consume[E, F]
+  final def consume[E](implicit F: Monad[F]): Iteratee[F, E, Vector[E]] = Iteratee.consume[F, E]
 
   final def collectT[E, A[_]](implicit
     M: Monad[F],
     mae: Monoid[A[E]],
     pointed: Applicative[A]
-  ): Iteratee[E, F, A[E]] = Iteratee.collectT[E, F, A]
+  ): Iteratee[F, E, A[E]] = Iteratee.collectT[F, E, A]
 
   /**
    * An iteratee that consumes the head of the input.
    */
-  final def head[E](implicit F: Applicative[F]): Iteratee[E, F, Option[E]] = Iteratee.head[E, F]
+  final def head[E](implicit F: Applicative[F]): Iteratee[F, E, Option[E]] = Iteratee.head[F, E]
 
   /**
    * An iteratee that returns the first element of the input.
    */
-  final def peek[E](implicit F: Applicative[F]): Iteratee[E, F, Option[E]] = Iteratee.peek[E, F]
+  final def peek[E](implicit F: Applicative[F]): Iteratee[F, E, Option[E]] = Iteratee.peek[F, E]
 
   /**
    * Iteratee that collects all inputs in reverse with the given reducer.
    *
    * This iteratee is useful for `F[_]` with efficient cons, e.g. `List`.
    */
-  final def reversed[E](implicit F: Applicative[F]): Iteratee[E, F, List[E]] = Iteratee.reversed[E, F]
+  final def reversed[E](implicit F: Applicative[F]): Iteratee[F, E, List[E]] = Iteratee.reversed[F, E]
 
   /**
    * Iteratee that collects the first `n` inputs.
    */
-  final def take[E](n: Int)(implicit F: Applicative[F]): Iteratee[E, F, Vector[E]] =
-    Iteratee.take[E, F](n)
+  final def take[E](n: Int)(implicit F: Applicative[F]): Iteratee[F, E, Vector[E]] =
+    Iteratee.take[F, E](n)
 
   /**
    * Iteratee that collects inputs until the input element fails a test.
    */
-  final def takeWhile[E](p: E => Boolean)(implicit F: Applicative[F]): Iteratee[E, F, Vector[E]] =
-    Iteratee.takeWhile[E, F](p)
+  final def takeWhile[E](p: E => Boolean)(implicit F: Applicative[F]): Iteratee[F, E, Vector[E]] =
+    Iteratee.takeWhile[F, E](p)
 
   /**
    * An iteratee that skips the first `n` elements of the input.
    */
-  final def drop[E](n: Int)(implicit F: Applicative[F]): Iteratee[E, F, Unit] = Iteratee.drop[E, F](n)
+  final def drop[E](n: Int)(implicit F: Applicative[F]): Iteratee[F, E, Unit] = Iteratee.drop[F, E](n)
 
   /**
    * An iteratee that skips elements while the predicate evaluates to true.
    */
-  final def dropWhile[E](p: E => Boolean)(implicit F: Applicative[F]): Iteratee[E, F, Unit] =
-    Iteratee.dropWhile[E, F](p)
+  final def dropWhile[E](p: E => Boolean)(implicit F: Applicative[F]): Iteratee[F, E, Unit] =
+    Iteratee.dropWhile[F, E](p)
 
-  final def fold[E, A](init: A)(f: (A, E) => A)(implicit F: Applicative[F]): Iteratee[E, F, A] =
-    Iteratee.fold[E, F, A](init)(f)
+  final def fold[E, A](init: A)(f: (A, E) => A)(implicit F: Applicative[F]): Iteratee[F, E, A] =
+    Iteratee.fold[F, E, A](init)(f)
 
-  final def foldM[E, A](init: A)(f: (A, E) => F[A])(implicit F: Monad[F]): Iteratee[E, F, A] =
-    Iteratee.foldM[E, F, A](init)(f)
+  final def foldM[E, A](init: A)(f: (A, E) => F[A])(implicit F: Monad[F]): Iteratee[F, E, A] =
+    Iteratee.foldM[F, E, A](init)(f)
 
   /**
    * An iteratee that counts and consumes the elements of the input
    */
-  final def length[E](implicit F: Applicative[F]): Iteratee[E, F, Int] = Iteratee.length[E, F]
+  final def length[E](implicit F: Applicative[F]): Iteratee[F, E, Int] = Iteratee.length[F, E]
 
   /**
    * An iteratee that checks if the input is EOF.
    */
-  final def isEnd[E](implicit F: Applicative[F]): Iteratee[E, F, Boolean] = Iteratee.isEnd[E, F]
+  final def isEnd[E](implicit F: Applicative[F]): Iteratee[F, E, Boolean] = Iteratee.isEnd[F, E]
 
-  final def sum[E: Monoid](implicit F: Monad[F]): Iteratee[E, F, E] = Iteratee.sum[E, F]
+  final def sum[E: Monoid](implicit F: Monad[F]): Iteratee[F, E, E] = Iteratee.sum[F, E]
 }

--- a/core/shared/src/main/scala/io/iteratee/Step.scala
+++ b/core/shared/src/main/scala/io/iteratee/Step.scala
@@ -12,14 +12,14 @@ import cats.Applicative
  * @tparam A The type of the result calculated by the [[Iteratee]]
  * @tparam B The type of the result of the fold
  */
-abstract class StepFolder[E, F[_], A, B] extends Serializable {
-  def onCont(k: Input[E] => Iteratee[E, F, A]): B
+abstract class StepFolder[F[_], E, A, B] extends Serializable {
+  def onCont(k: Input[E] => Iteratee[F, E, A]): B
   def onDone(value: A, remainder: Input[E]): B
 }
 
-abstract class MapContStepFolder[E, F[_]: Applicative, A](step: Step[E, F, A])
-  extends StepFolder[E, F, A, Iteratee[E, F, A]] {
-    final def onDone(value: A, remainder: Input[E]): Iteratee[E, F, A] = step.pointI
+abstract class MapContStepFolder[F[_]: Applicative, E, A](step: Step[F, E, A])
+  extends StepFolder[F, E, A, Iteratee[F, E, A]] {
+    final def onDone(value: A, remainder: Input[E]): Iteratee[F, E, A] = step.pointI
   }
 
 /**
@@ -32,7 +32,7 @@ abstract class MapContStepFolder[E, F[_]: Applicative, A](step: Step[E, F, A])
  * @tparam F The effect type constructor
  * @tparam A The type of the result calculated by the [[Iteratee]]
  */
-sealed abstract class Step[E, F[_], A] extends Serializable {
+sealed abstract class Step[F[_], E, A] extends Serializable {
   /**
    * The [[Iteratee]]'s result.
    *
@@ -45,32 +45,32 @@ sealed abstract class Step[E, F[_], A] extends Serializable {
   /**
    * Reduce this [[Step]] to a value using the given pair of functions.
    */
-  def foldWith[B](folder: StepFolder[E, F, A, B]): B
+  def foldWith[B](folder: StepFolder[F, E, A, B]): B
 
   def isDone: Boolean
 
   /**
    * Create an [[Iteratee]] with this [[Step]] as its state.
    */
-  final def pointI(implicit F: Applicative[F]): Iteratee[E, F, A] = Iteratee.iteratee(F.pure(this))
+  final def pointI(implicit F: Applicative[F]): Iteratee[F, E, A] = Iteratee.iteratee(F.pure(this))
 }
 
 final object Step {
   /**
    * Create an incomplete state that will use the given function to process the next input.
    */
-  final def cont[E, F[_], A](k: Input[E] => Iteratee[E, F, A]): Step[E, F, A] = new Step[E, F, A] {
+  final def cont[F[_], E, A](k: Input[E] => Iteratee[F, E, A]): Step[F, E, A] = new Step[F, E, A] {
     private[iteratee] final def unsafeValue: A = Iteratee.diverge[A]
     final def isDone: Boolean = false
-    final def foldWith[B](folder: StepFolder[E, F, A, B]): B = folder.onCont(k)
+    final def foldWith[B](folder: StepFolder[F, E, A, B]): B = folder.onCont(k)
   }
 
   /**
    * Create a new completed state with the given result and leftover input.
    */
-  final def done[E, F[_], A](value: A, remaining: Input[E]): Step[E, F, A] = new Step[E, F, A] {
+  final def done[F[_], E, A](value: A, remaining: Input[E]): Step[F, E, A] = new Step[F, E, A] {
     private[iteratee] final def unsafeValue: A = value
     final def isDone: Boolean = true
-    final def foldWith[B](folder: StepFolder[E, F, A, B]): B = folder.onDone(value, remaining)
+    final def foldWith[B](folder: StepFolder[F, E, A, B]): B = folder.onDone(value, remaining)
   }
 }

--- a/core/shared/src/main/scala/io/iteratee/package.scala
+++ b/core/shared/src/main/scala/io/iteratee/package.scala
@@ -2,12 +2,7 @@ package io
 
 import cats.{ Eval, Id }
 
-package object iteratee {
-  type PureStep[E, A] = Step[E, Id, A]
-  type PureIteratee[E, A] = Iteratee[E, Id, A]
-  type PureEnumerator[E] = Enumerator[E, Id]
-  type PureEnumeratee[O, I] = Enumeratee[O, I, Id]
-}
+package object iteratee
 
 package iteratee {
   final object pure extends Module[Id]

--- a/core/shared/src/test/scala/io/iteratee/ArbitraryInstances.scala
+++ b/core/shared/src/test/scala/io/iteratee/ArbitraryInstances.scala
@@ -14,35 +14,35 @@ trait ArbitraryInstances {
       )
     )
 
-  implicit def arbitraryEnumerator[A, F[_]: Monad](implicit
+  implicit def arbitraryEnumerator[F[_]: Monad, A](implicit
     A: Arbitrary[A]
-  ): Arbitrary[Enumerator[A, F]] =
+  ): Arbitrary[Enumerator[F, A]] =
     Arbitrary(
       Gen.containerOfN[List, A](10, A.arbitrary).flatMap(as =>
         Gen.oneOf(
-          Enumerator.enumList[A, F](as),
-          Enumerator.enumStream[A, F](as.toStream)
+          Enumerator.enumList[F, A](as),
+          Enumerator.enumStream[F, A](as.toStream)
         )
       )
     )
 
-  implicit def arbitraryIteratee[A, F[_]: Monad](implicit
+  implicit def arbitraryIteratee[F[_]: Monad, A](implicit
     A: Arbitrary[A]
-  ): Arbitrary[Iteratee[Vector[A], F, Vector[A]]] = {
-    val m: Monad[({ type L[x] = Iteratee[Vector[A], F, x] })#L] = implicitly
-    val f = Iteratee.fold[Vector[A], F, Vector[A]](Vector.empty)(_ ++ _)
+  ): Arbitrary[Iteratee[F, Vector[A], Vector[A]]] = {
+    val m: Monad[({ type L[x] = Iteratee[F, Vector[A], x] })#L] = implicitly
+    val f = Iteratee.fold[F, Vector[A], Vector[A]](Vector.empty)(_ ++ _)
 
     Arbitrary(
       for {
         n <- Gen.chooseNum(0, 16)
         xs <- Gen.containerOfN[Vector, A](128, A.arbitrary)
         it <- Gen.oneOf(
-          Iteratee.drop[Vector[A], F](n).flatMap(_ => f),
-          Iteratee.drop[Vector[A], F](n).flatMap(_ => m.pure(xs)),
-          Iteratee.peek[Vector[A], F].flatMap(_ => f),
-          Iteratee.peek[Vector[A], F].flatMap(_ => m.pure(xs)),
-          Iteratee.identity[Vector[A], F].flatMap(_ => f),
-          Iteratee.identity[Vector[A], F].flatMap(_ => m.pure(xs))
+          Iteratee.drop[F, Vector[A]](n).flatMap(_ => f),
+          Iteratee.drop[F, Vector[A]](n).flatMap(_ => m.pure(xs)),
+          Iteratee.peek[F, Vector[A]].flatMap(_ => f),
+          Iteratee.peek[F, Vector[A]].flatMap(_ => m.pure(xs)),
+          Iteratee.identity[F, Vector[A]].flatMap(_ => f),
+          Iteratee.identity[F, Vector[A]].flatMap(_ => m.pure(xs))
         )
       } yield it
     )

--- a/core/shared/src/test/scala/io/iteratee/EqInstances.scala
+++ b/core/shared/src/test/scala/io/iteratee/EqInstances.scala
@@ -5,16 +5,16 @@ import cats.Monad
 import org.scalacheck.Arbitrary
 
 trait EqInstances {
-  implicit def eqEnumerator[A: Eq, F[_]: Monad](implicit
+  implicit def eqEnumerator[F[_]: Monad, A: Eq](implicit
     eq: Eq[F[Vector[A]]]
-  ): Eq[Enumerator[A, F]] = eq.on[Enumerator[A, F]](_.drain)
+  ): Eq[Enumerator[F, A]] = eq.on[Enumerator[F, A]](_.drain)
 
   implicit def eqIteratee[A: Eq: Arbitrary, F[_]: Monad](implicit
     eq: Eq[F[Vector[A]]]
-  ): Eq[Iteratee[Vector[A], F, Vector[A]]] = {
-    val e0 = Enumerator.empty[Vector[A], F]
-    val e1 = Enumerator.enumList[Vector[A], F](Arbitrary.arbitrary[List[Vector[A]]].sample.get)
-    val e2 = Enumerator.enumStream[Vector[A], F](Arbitrary.arbitrary[Stream[Vector[A]]].sample.get)
+  ): Eq[Iteratee[F, Vector[A], Vector[A]]] = {
+    val e0 = Enumerator.empty[F, Vector[A]]
+    val e1 = Enumerator.enumList[F, Vector[A]](Arbitrary.arbitrary[List[Vector[A]]].sample.get)
+    val e2 = Enumerator.enumStream[F, Vector[A]](Arbitrary.arbitrary[Stream[Vector[A]]].sample.get)
 
     Eq.instance { (i, j) =>
       eq.eqv(i.process(e0), j.process(e0)) &&

--- a/core/shared/src/test/scala/io/iteratee/SizedEnumerator.scala
+++ b/core/shared/src/test/scala/io/iteratee/SizedEnumerator.scala
@@ -6,25 +6,25 @@ import org.scalacheck.{ Arbitrary, Gen }
 
 trait SizedEnumerator[A] {
 	def source: Stream[A]
-	def enumerator: Enumerator[A, Eval]
+	def enumerator: Enumerator[Eval, A]
 }
 
 trait SizedEnumeratorCompanion[E[x] <: SizedEnumerator[x]] {
   def maxGroupSize: Int
   def maxGroupCount: Int
 
-  def apply[A](source: Stream[A], enumerator: Enumerator[A, Eval]): E[A]
+  def apply[A](source: Stream[A], enumerator: Enumerator[Eval, A]): E[A]
 
-  def pair[A](implicit A: Arbitrary[A]): Gen[(Stream[A], Enumerator[A, Eval])] =
+  def pair[A](implicit A: Arbitrary[A]): Gen[(Stream[A], Enumerator[Eval, A])] =
     Gen.oneOf(
-      Gen.const((Stream.empty[A], Enumerator.empty[A, Eval])),
-      A.arbitrary.map(a => (Stream(a), Enumerator.enumOne[A, Eval](a))),
+      Gen.const((Stream.empty[A], Enumerator.empty[Eval, A])),
+      A.arbitrary.map(a => (Stream(a), Enumerator.enumOne[Eval, A](a))),
       for {
         size <- Gen.chooseNum(0, maxGroupSize)
         vals <- Gen.containerOfN[Stream, A](size, A.arbitrary)
         enum <- Gen.oneOf(
-          Enumerator.enumStream[A, Eval](vals),
-          Enumerator.enumList[A, Eval](vals.toList)
+          Enumerator.enumStream[Eval, A](vals),
+          Enumerator.enumList[Eval, A](vals.toList)
         )
       } yield (vals, enum)
     )
@@ -35,15 +35,15 @@ trait SizedEnumeratorCompanion[E[x] <: SizedEnumerator[x]] {
     Arbitrary(
     	for {
         size <- Gen.chooseNum(0, maxGroupCount)
-        groups <- Gen.containerOfN[Stream, (Stream[A], Enumerator[A, Eval])](size, pair[A])
+        groups <- Gen.containerOfN[Stream, (Stream[A], Enumerator[Eval, A])](size, pair[A])
         (ss, es) = groups.unzip
-      } yield apply(ss.flatten, Monoid[Enumerator[A, Eval]].combineAll(es))
+      } yield apply(ss.flatten, Monoid[Enumerator[Eval, A]].combineAll(es))
     )
 }
 
 case class SmallEnumerator[A](
 	source: Stream[A],
-	enumerator: Enumerator[A, Eval]
+	enumerator: Enumerator[Eval, A]
 ) extends SizedEnumerator[A]
 
 object SmallEnumerator extends SizedEnumeratorCompanion[SmallEnumerator] {
@@ -53,7 +53,7 @@ object SmallEnumerator extends SizedEnumeratorCompanion[SmallEnumerator] {
 
 case class LargeEnumerator[A](
 	source: Stream[A],
-	enumerator: Enumerator[A, Eval]
+	enumerator: Enumerator[Eval, A]
 ) extends SizedEnumerator[A]
 
 object LargeEnumerator extends SizedEnumeratorCompanion[LargeEnumerator] {


### PR DESCRIPTION
I'd been following the traditional order of type parameters, but I think putting the type constructor first everywhere is clearer and more consistent.