### PR TITLE
Upgrade to Cats 0.4.0-SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val compilerOptions = Seq(
   "-Xfuture"
 )
 
-lazy val catsVersion = "0.3.0"
+lazy val catsVersion = "0.4.0-SNAPSHOT"
 lazy val scalaTestVersion = "3.0.0-M9"
 
 lazy val baseSettings = Seq(

--- a/core/shared/src/test/scala/io/iteratee/EnumeratorSuite.scala
+++ b/core/shared/src/test/scala/io/iteratee/EnumeratorSuite.scala
@@ -4,11 +4,14 @@ import algebra.Eq
 import algebra.laws.GroupLaws
 import cats.{ Eval, Monad }
 import cats.data.XorT
-import cats.laws.discipline.MonadTests
+import cats.laws.discipline.{ MonadTests, MonoidalTests }
 import org.scalacheck.{ Gen, Prop }
 
 abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
   type EnumeratorF[E] = Enumerator[F, E]
+
+  implicit val isomorphisms: MonoidalTests.Isomorphisms[EnumeratorF] =
+    MonoidalTests.Isomorphisms.invariant[EnumeratorF]
 
   checkAll(s"Enumerator[$monadName, Int]", GroupLaws[Enumerator[F, Int]].monoid)
   checkAll(s"Enumerator[$monadName, Int]", MonadTests[EnumeratorF].monad[Int, Int, Int])

--- a/core/shared/src/test/scala/io/iteratee/EqInstances.scala
+++ b/core/shared/src/test/scala/io/iteratee/EqInstances.scala
@@ -9,13 +9,13 @@ trait EqInstances {
     eq: Eq[F[Vector[A]]]
   ): Eq[Enumerator[F, A]] = eq.on[Enumerator[F, A]](_.drain)
 
-  implicit def eqIteratee[F[_]: Monad, A: Eq: Arbitrary](implicit
-    eq: Eq[F[Vector[A]]]
-  ): Eq[Iteratee[F, Vector[A], Vector[A]]] = {
-    val e0 = Enumerator.empty[F, Vector[A]]
-    val e1 = Enumerator.enumList[F, Vector[A]](Arbitrary.arbitrary[List[Vector[A]]].sample.get)
-    val e2 = Enumerator.enumStream[F, Vector[A]](Arbitrary.arbitrary[Stream[Vector[A]]].sample.get)
-    val e3 = Enumerator.enumVector[F, Vector[A]](Arbitrary.arbitrary[Vector[Vector[A]]].sample.get)
+  implicit def eqIteratee[F[_]: Monad, A: Eq: Arbitrary, B: Eq: Arbitrary](implicit
+    eq: Eq[F[B]]
+  ): Eq[Iteratee[F, A, B]] = {
+    val e0 = Enumerator.empty[F, A]
+    val e1 = Enumerator.enumList[F, A](Arbitrary.arbitrary[List[A]].sample.get)
+    val e2 = Enumerator.enumStream[F, A](Arbitrary.arbitrary[Stream[A]].sample.get)
+    val e3 = Enumerator.enumVector[F, A](Arbitrary.arbitrary[Vector[A]].sample.get)
 
     Eq.instance { (i, j) =>
       eq.eqv(i.process(e0), j.process(e0)) &&

--- a/core/shared/src/test/scala/io/iteratee/IterateeSuite.scala
+++ b/core/shared/src/test/scala/io/iteratee/IterateeSuite.scala
@@ -2,7 +2,7 @@ package io.iteratee
 
 import cats.{ Eval, Id, Monad }
 import cats.arrow.NaturalTransformation
-import cats.laws.discipline.{ ContravariantTests, MonadTests }
+import cats.laws.discipline.{ ContravariantTests, MonadTests, MonoidalTests }
 import org.scalacheck.Prop.BooleanOperators
 
 abstract class IterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
@@ -13,6 +13,9 @@ abstract class IterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
 
   type VectorIntProducingIteratee[E] = Iteratee[F, E, Vector[Int]]
   type VectorIntFoldingIteratee[A] = Iteratee[F, Vector[Int], A]
+
+  implicit val isomorphisms: MonoidalTests.Isomorphisms[VectorIntFoldingIteratee] =
+    MonoidalTests.Isomorphisms.invariant[VectorIntFoldingIteratee]
 
   checkAll(
     s"Iteratee[$monadName, Vector[Int], Vector[Int]]",

--- a/core/shared/src/test/scala/io/iteratee/package.scala
+++ b/core/shared/src/test/scala/io/iteratee/package.scala
@@ -8,6 +8,11 @@ package object iteratee {
     Eq.instance {
       case ((a1, a2), (b1, b2)) => A.eqv(a1, b1) && B.eqv(a2, b2)
     }
+
+  implicit def eqTuple3[A, B, C](implicit A: Eq[A], B: Eq[B], C: Eq[C]): Eq[(A, B, C)] =
+    Eq.instance {
+      case ((a1, b1, c1), (a2, b2, c2)) => A.eqv(a1, a2) && B.eqv(b1, b2) && C.eqv(c1, c2)
+    }
 }
 
 package iteratee {


### PR DESCRIPTION
Not sure why I need the manually-defined `MonoidalTests.Isomorphisms` instances, but oh well.