### PR TITLE
Remove redundant helper methods on Enumerator

### DIFF
--- a/core/src/main/scala/io/iteratee/Enumerator.scala
+++ b/core/src/main/scala/io/iteratee/Enumerator.scala
@@ -38,37 +38,18 @@ abstract class Enumerator[F[_], E] extends Serializable { self =>
       }
     )
 
-  final def collect[B](pf: PartialFunction[E, B])(implicit F: Monad[F]): Enumerator[F, B] = mapE(Enumeratee.collect(pf))
-
-  final def filter(p: E => Boolean)(implicit F: Monad[F]): Enumerator[F, E] = mapE(Enumeratee.filter(p))
-
-  final def sequenceI[I](iteratee: Iteratee[F, E, I])(implicit F: Monad[F]): Enumerator[F, I] =
-    mapE(Enumeratee.sequenceI(iteratee))
-
   final def ensure[T](action: F[Unit])(implicit F: MonadError[F, T]): Enumerator[F, E] = new Enumerator[F, E] {
     final def apply[A](s: Step[F, E, A]): F[Step[F, E, A]] = F.flatMap(
       F.handleErrorWith(self(s))(e => F.flatMap(action)(_ => F.raiseError(e)))
     )(result => F.map(action)(_ => result))
   }
 
-  final def uniq(implicit F: Monad[F], E: Order[E]): Enumerator[F, E] = mapE(Enumeratee.uniq)
-
-  final def zipWithIndex(implicit F: Monad[F]): Enumerator[F, (E, Long)] = mapE(Enumeratee.zipWithIndex)
-
-  final def grouped(n: Int)(implicit F: Monad[F]): Enumerator[F, Vector[E]] = mapE(Enumeratee.grouped(n))
-
-  final def splitOn(p: E => Boolean)(implicit F: Monad[F]): Enumerator[F, Vector[E]] = mapE(Enumeratee.splitOn(p))
-
-  final def drain(implicit F: Monad[F]): F[Vector[E]] = run(Iteratee.drain)
-
-  final def drainTo[C[_]: Applicative: MonoidK](implicit F: Monad[F]): F[C[E]] = run(Iteratee.drainTo)
+  final def toVector(implicit F: Monad[F]): F[Vector[E]] = run(Iteratee.drain)
 
   final def reduced[B](b: B)(f: (B, E) => B)(implicit F: Monad[F]): Enumerator[F, B] = new Enumerator[F, B] {
     final def apply[A](step: Step[F, B, A]): F[Step[F, B, A]] =
       F.flatMap(self(Step.fold[F, E, B](b)(f)))(next => F.flatMap(next.run)(step.feedEl))
   }
-
-  final def cross[E2](e2: Enumerator[F, E2])(implicit M: Monad[F]): Enumerator[F, (E, E2)] = mapE(Enumeratee.cross(e2))
 
   final def handleErrorWith[T](f: T => Enumerator[F, E])(implicit F: MonadError[F, T]): Enumerator[F, E] =
     new Enumerator[F, E] {

--- a/core/src/main/scala/io/iteratee/Enumerator.scala
+++ b/core/src/main/scala/io/iteratee/Enumerator.scala
@@ -16,79 +16,59 @@ abstract class Enumerator[F[_], E] extends Serializable { self =>
 
   final def map[B](f: E => B)(implicit F: Monad[F]): Enumerator[F, B] = mapE(Enumeratee.map(f))
 
-  final def flatMap[B](f: E => Enumerator[F, B])(implicit F: Monad[F]): Enumerator[F, B] =
-    mapE(Enumeratee.flatMap(f))
+  final def flatMap[B](f: E => Enumerator[F, B])(implicit F: Monad[F]): Enumerator[F, B] = mapE(Enumeratee.flatMap(f))
 
-  final def prepend(e: E)(implicit F: Monad[F]): Enumerator[F, E] = {
-    new Enumerator[F, E] {
-      def apply[A](step: Step[F, E, A]): F[Step[F, E, A]] = if (step.isDone) self(step) else
-        F.flatMap(step.feedEl(e))(self(_))
-    }
+  final def prepend(e: E)(implicit F: Monad[F]): Enumerator[F, E] = new Enumerator[F, E] {
+    def apply[A](step: Step[F, E, A]): F[Step[F, E, A]] =
+      if (step.isDone) self(step) else F.flatMap(step.feedEl(e))(self(_))
   }
 
-  final def append(e2: Enumerator[F, E])(implicit F: FlatMap[F]): Enumerator[F, E] =
-    new Enumerator[F, E] {
-      final def apply[A](s: Step[F, E, A]): F[Step[F, E, A]] = F.flatMap(self(s))(e2(_))
-    }
-
-  final def flatten[B](implicit M: Monad[F], ev: E =:= F[B]): Enumerator[F, B] =
-    flatMap(e => Enumerator.liftM(ev(e)))
-
-  final def bindM[G[_], B](f: E => G[Enumerator[F, B]])(implicit
-    F: Monad[F],
-    G: Monad[G]
-  ): F[G[Enumerator[F, B]]] = {
-    val iteratee = Iteratee.fold[F, G[Enumerator[F, B]], G[Enumerator[F, B]]](
-      G.pure(Enumerator.empty)
-    ) {
-      case (acc, concat) => G.flatMap(acc)(en =>
-        G.map(concat)(append => Semigroup[Enumerator[F, B]].combine(en, append))
-      )
-    }
-
-    map(f).run(iteratee)
+  final def append(e2: Enumerator[F, E])(implicit F: FlatMap[F]): Enumerator[F, E] = new Enumerator[F, E] {
+    final def apply[A](s: Step[F, E, A]): F[Step[F, E, A]] = F.flatMap(self(s))(e2(_))
   }
 
-  final def collect[B](pf: PartialFunction[E, B])(implicit F: Monad[F]): Enumerator[F, B] =
-    mapE(Enumeratee.collect(pf))
+  final def flatten[B](implicit M: Monad[F], ev: E =:= F[B]): Enumerator[F, B] = flatMap(e => Enumerator.liftM(ev(e)))
 
-  final def filter(p: E => Boolean)(implicit F: Monad[F]): Enumerator[F, E] =
-    mapE(Enumeratee.filter(p))
+  final def bindM[G[_], B](f: E => G[Enumerator[F, B]])(implicit F: Monad[F], G: Monad[G]): F[G[Enumerator[F, B]]] =
+    map(f).run(
+      Iteratee.fold[F, G[Enumerator[F, B]], G[Enumerator[F, B]]](G.pure(Enumerator.empty)) {
+        case (acc, concat) => G.flatMap(acc)(en =>
+          G.map(concat)(append => Semigroup[Enumerator[F, B]].combine(en, append))
+        )
+      }
+    )
+
+  final def collect[B](pf: PartialFunction[E, B])(implicit F: Monad[F]): Enumerator[F, B] = mapE(Enumeratee.collect(pf))
+
+  final def filter(p: E => Boolean)(implicit F: Monad[F]): Enumerator[F, E] = mapE(Enumeratee.filter(p))
 
   final def sequenceI[I](iteratee: Iteratee[F, E, I])(implicit F: Monad[F]): Enumerator[F, I] =
     mapE(Enumeratee.sequenceI(iteratee))
 
-  final def ensure[T](action: F[Unit])(implicit F: MonadError[F, T]): Enumerator[F, E] =
-    new Enumerator[F, E] {
-      final def apply[A](s: Step[F, E, A]): F[Step[F, E, A]] = F.flatMap(
-        F.handleErrorWith(self(s))(e => F.flatMap(action)(_ => F.raiseError(e)))
-      )(result => F.map(action)(_ => result))
-    }
+  final def ensure[T](action: F[Unit])(implicit F: MonadError[F, T]): Enumerator[F, E] = new Enumerator[F, E] {
+    final def apply[A](s: Step[F, E, A]): F[Step[F, E, A]] = F.flatMap(
+      F.handleErrorWith(self(s))(e => F.flatMap(action)(_ => F.raiseError(e)))
+    )(result => F.map(action)(_ => result))
+  }
 
   final def uniq(implicit F: Monad[F], E: Order[E]): Enumerator[F, E] = mapE(Enumeratee.uniq)
 
-  final def zipWithIndex(implicit F: Monad[F]): Enumerator[F, (E, Long)] =
-    mapE(Enumeratee.zipWithIndex)
+  final def zipWithIndex(implicit F: Monad[F]): Enumerator[F, (E, Long)] = mapE(Enumeratee.zipWithIndex)
 
-  final def grouped(n: Int)(implicit F: Monad[F]): Enumerator[F, Vector[E]] =
-    mapE(Enumeratee.grouped(n))
+  final def grouped(n: Int)(implicit F: Monad[F]): Enumerator[F, Vector[E]] = mapE(Enumeratee.grouped(n))
 
-  final def splitOn(p: E => Boolean)(implicit F: Monad[F]): Enumerator[F, Vector[E]] =
-    mapE(Enumeratee.splitOn(p))
+  final def splitOn(p: E => Boolean)(implicit F: Monad[F]): Enumerator[F, Vector[E]] = mapE(Enumeratee.splitOn(p))
 
   final def drain(implicit F: Monad[F]): F[Vector[E]] = run(Iteratee.drain)
 
-  final def drainTo[C[_]: Applicative: MonoidK](implicit F: Monad[F]): F[C[E]] =
-    run(Iteratee.drainTo)
+  final def drainTo[C[_]: Applicative: MonoidK](implicit F: Monad[F]): F[C[E]] = run(Iteratee.drainTo)
 
-  final def reduced[B](b: B)(f: (B, E) => B)(implicit F: Monad[F]): Enumerator[F, B] =
-    new Enumerator[F, B] {
-      final def apply[A](step: Step[F, B, A]): F[Step[F, B, A]] =
-        F.flatMap(self(Step.fold[F, E, B](b)(f)))(next => F.flatMap(next.run)(step.feedEl))
-    }
+  final def reduced[B](b: B)(f: (B, E) => B)(implicit F: Monad[F]): Enumerator[F, B] = new Enumerator[F, B] {
+    final def apply[A](step: Step[F, B, A]): F[Step[F, B, A]] =
+      F.flatMap(self(Step.fold[F, E, B](b)(f)))(next => F.flatMap(next.run)(step.feedEl))
+  }
 
-  final def cross[E2](e2: Enumerator[F, E2])(implicit M: Monad[F]): Enumerator[F, (E, E2)] =
-    mapE(Enumeratee.cross(e2))
+  final def cross[E2](e2: Enumerator[F, E2])(implicit M: Monad[F]): Enumerator[F, (E, E2)] = mapE(Enumeratee.cross(e2))
 
   final def handleErrorWith[T](f: T => Enumerator[F, E])(implicit F: MonadError[F, T]): Enumerator[F, E] =
     new Enumerator[F, E] {

--- a/tests/jvm/src/it/scala/io/iteratee/task/TaskOperationTests.scala
+++ b/tests/jvm/src/it/scala/io/iteratee/task/TaskOperationTests.scala
@@ -38,19 +38,19 @@ class TaskOperationTest extends BaseSuite {
     val dir = new File(getClass.getResource("/io/iteratee/examples/pg/11231").toURI)
     val result = Vector("11231.txt", "11231.zip")
 
-    assert(listContents(dir).drain.run.map(_.getName).sorted === result)
+    assert(listContents(dir).toVector.run.map(_.getName).sorted === result)
   }
 
   test("listContents on file") {
     val notDir = new File(getClass.getResource("/io/iteratee/examples/pg/11231/11231.txt").toURI)
 
-    assert(listContents(notDir).drain.run.isEmpty)
+    assert(listContents(notDir).toVector.run.isEmpty)
   }
 
   test("listAllFiles") {
     val dir = new File(getClass.getResource("/io/iteratee/examples/pg").toURI)
     val result = Vector("11231.txt", "11231.zip")
 
-    assert(listAllFiles(dir).drain.run.map(_.getName).sorted === result)
+    assert(listAllFiles(dir).toVector.run.map(_.getName).sorted === result)
   }
 }

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
@@ -13,7 +13,7 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
 
   test("map") {
     check { (eav: EnumeratorAndValues[Int]) =>
-      eav.enumerator.mapE(map(_ + 1)).drain === F.pure(eav.values.map(_ + 1))
+      eav.enumerator.mapE(map(_ + 1)).toVector === F.pure(eav.values.map(_ + 1))
     }
   }
 
@@ -21,7 +21,7 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     check { (eav: EnumeratorAndValues[Int]) =>
       val enumerator = eav.enumerator.mapE(flatMap(v => enumVector(Vector(v, v))))
 
-      enumerator.drain === F.pure(eav.values.flatMap(v => Vector(v, v)))
+      enumerator.toVector === F.pure(eav.values.flatMap(v => Vector(v, v)))
     }
   }
 
@@ -43,7 +43,7 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
         case v if v % 2 == 0 => v + 1
       }
 
-      eav.enumerator.mapE(collect(pf)).drain === F.pure(eav.values.collect(pf))
+      eav.enumerator.mapE(collect(pf)).toVector === F.pure(eav.values.collect(pf))
     }
   }
 
@@ -51,14 +51,14 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     check { (eav: EnumeratorAndValues[Int]) =>
       val p: Int => Boolean = _ % 2 == 0
 
-      eav.enumerator.mapE(filter(p)).drain === F.pure(eav.values.filter(p))
+      eav.enumerator.mapE(filter(p)).toVector === F.pure(eav.values.filter(p))
     }
   }
 
   test("sequenceI") {
     check { (eav: EnumeratorAndValues[Int]) =>
       Prop.forAll(Gen.posNum[Int]) { n =>
-        eav.enumerator.mapE(sequenceI(take(n))).drain === F.pure(eav.values.grouped(n).toVector)
+        eav.enumerator.mapE(sequenceI(take(n))).toVector === F.pure(eav.values.grouped(n).toVector)
       }
     }
   }
@@ -75,7 +75,7 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     check { (xs: Vector[Int]) =>
       val sorted = xs.sorted
 
-      enumVector(sorted).mapE(uniq).drain === F.pure(sorted.distinct)
+      enumVector(sorted).mapE(uniq).toVector === F.pure(sorted.distinct)
     }
   }
 
@@ -96,7 +96,7 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
       .append(enumVector(Vector(9, 10)))
     val result = Vector(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 
-    assert(enumerator.mapE(uniq).drain === F.pure(result))
+    assert(enumerator.mapE(uniq).toVector === F.pure(result))
   }
 
   test("zipWithIndex") {
@@ -105,7 +105,7 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
         case (v, i) => (v, i.toLong)
       }
 
-      eav.enumerator.mapE(zipWithIndex).drain === F.pure(result)
+      eav.enumerator.mapE(zipWithIndex).toVector === F.pure(result)
     }
   }
 
@@ -122,7 +122,7 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
   test("grouped") {
     check { (eav: EnumeratorAndValues[Int]) =>
       Prop.forAll(Gen.posNum[Int]) { n =>
-        eav.enumerator.mapE(grouped(n)).drain === F.pure(eav.values.grouped(n).toVector)
+        eav.enumerator.mapE(grouped(n)).toVector === F.pure(eav.values.grouped(n).toVector)
       }
     }
   }
@@ -137,7 +137,7 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
         before +: splitOnEvens(after.drop(1))
       }
 
-      eav.enumerator.mapE(splitOn(p)).drain === F.pure(splitOnEvens(eav.values))
+      eav.enumerator.mapE(splitOn(p)).toVector === F.pure(splitOnEvens(eav.values))
     }
   }
 
@@ -148,7 +148,7 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
         v2 <- eav2.values
       } yield (v1, v2)
 
-      eav1.enumerator.mapE(cross(eav2.enumerator)).drain === F.pure(result)
+      eav1.enumerator.mapE(cross(eav2.enumerator)).toVector === F.pure(result)
     }
   }
 }

--- a/tests/shared/src/main/scala/io/iteratee/tests/EqInstances.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EqInstances.scala
@@ -6,21 +6,18 @@ import io.iteratee.{ Enumeratee, Enumerator, Iteratee }
 import org.scalacheck.Arbitrary
 
 trait EqInstances {
-  implicit def eqTuple2[A, B](implicit A: Eq[A], B: Eq[B]): Eq[(A, B)] =
-    Eq.instance {
-      case ((a1, a2), (b1, b2)) => A.eqv(a1, b1) && B.eqv(a2, b2)
-    }
+  implicit def eqTuple2[A, B](implicit A: Eq[A], B: Eq[B]): Eq[(A, B)] = Eq.instance {
+    case ((a1, a2), (b1, b2)) => A.eqv(a1, b1) && B.eqv(a2, b2)
+  }
 
-  implicit def eqTuple3[A, B, C](implicit A: Eq[A], B: Eq[B], C: Eq[C]): Eq[(A, B, C)] =
-    Eq.instance {
-      case ((a1, b1, c1), (a2, b2, c2)) => A.eqv(a1, a2) && B.eqv(b1, b2) && C.eqv(c1, c2)
-    }
+  implicit def eqTuple3[A, B, C](implicit A: Eq[A], B: Eq[B], C: Eq[C]): Eq[(A, B, C)] = Eq.instance {
+    case ((a1, b1, c1), (a2, b2, c2)) => A.eqv(a1, a2) && B.eqv(b1, b2) && C.eqv(c1, c2)
+  }
 
   implicit val eqThrowable: Eq[Throwable] = Eq.fromUniversalEquals
 
-  implicit def eqEnumerator[F[_]: Monad, A: Eq](implicit
-    eq: Eq[F[Vector[A]]]
-  ): Eq[Enumerator[F, A]] = eq.on[Enumerator[F, A]](_.drain)
+  implicit def eqEnumerator[F[_]: Monad, A: Eq](implicit eq: Eq[F[Vector[A]]]): Eq[Enumerator[F, A]] =
+    eq.on[Enumerator[F, A]](_.toVector)
 
   implicit def eqIteratee[F[_]: Monad, A: Eq: Arbitrary, B: Eq: Arbitrary](implicit
     eq: Eq[F[B]]
@@ -47,10 +44,10 @@ trait EqInstances {
     val e3 = Enumerator.enumVector[F, A](Arbitrary.arbitrary[Vector[A]].sample.get)
 
     Eq.instance { (i, j) =>
-      eq.eqv(e0.mapE(i).drain, e0.mapE(j).drain) &&
-      eq.eqv(e1.mapE(i).drain, e1.mapE(j).drain) &&
-      eq.eqv(e2.mapE(i).drain, e2.mapE(j).drain) &&
-      eq.eqv(e3.mapE(i).drain, e3.mapE(j).drain)
+      eq.eqv(e0.mapE(i).toVector, e0.mapE(j).toVector) &&
+      eq.eqv(e1.mapE(i).toVector, e1.mapE(j).toVector) &&
+      eq.eqv(e2.mapE(i).toVector, e2.mapE(j).toVector) &&
+      eq.eqv(e3.mapE(i).toVector, e3.mapE(j).toVector)
     }
   }
 }

--- a/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
@@ -74,7 +74,7 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
         F.pure(acc)
       )
 
-      eav.enumerator.run(myDrain(Nil)) === F.map(eav.enumerator.drain)(_.toList)
+      eav.enumerator.run(myDrain(Nil)) === F.map(eav.enumerator.toVector)(_.toList)
     }
   }
 

--- a/tests/shared/src/test/scala/io/iteratee/EvalTests.scala
+++ b/tests/shared/src/test/scala/io/iteratee/EvalTests.scala
@@ -12,7 +12,7 @@ class EvalEnumeratorTests extends EnumeratorSuite[Eval] with EvalSuite {
       val action = perform[Int](Eval.always(counter += 1))
       val enumerator = action.append(eav.enumerator).append(action)
 
-      counter === 0 && enumerator.drain === F.pure(eav.values) && counter === 2
+      counter === 0 && enumerator.toVector === F.pure(eav.values) && counter === 2
     }
   }
 }

--- a/tests/shared/src/test/scala/io/iteratee/XorTests.scala
+++ b/tests/shared/src/test/scala/io/iteratee/XorTests.scala
@@ -19,7 +19,7 @@ class XorEnumeratorTests extends EnumeratorSuite[({ type L[x] = XorT[Eval, Throw
       val action = XorT.right[Eval, Throwable, Unit](Eval.always(counter += 1))
       val enumerator = eav.enumerator.ensure(action)
 
-      counter == 0 && enumerator.drain === F.pure(eav.values) && counter === 1
+      counter == 0 && enumerator.toVector === F.pure(eav.values) && counter === 1
     }
   }
 
@@ -30,7 +30,7 @@ class XorEnumeratorTests extends EnumeratorSuite[({ type L[x] = XorT[Eval, Throw
       val action = XorT.right[Eval, Throwable, Unit](Eval.always(counter += 1))
       val enumerator = failEnumerator(error).append(eav.enumerator).ensure(action)
 
-      counter == 0 && enumerator.drain.value.value === Xor.left(error) && counter === 1
+      counter == 0 && enumerator.toVector.value.value === Xor.left(error) && counter === 1
     }
   }
 
@@ -49,7 +49,7 @@ class XorEnumeratorTests extends EnumeratorSuite[({ type L[x] = XorT[Eval, Throw
     check { (eav: EnumeratorAndValues[Int], message: String) =>
       val error: Throwable = new Exception(message)
 
-      eav.enumerator.append(failEnumerator(error)).drain.value.value === Xor.left(error)
+      eav.enumerator.append(failEnumerator(error)).toVector.value.value === Xor.left(error)
     }
   }
 
@@ -58,7 +58,7 @@ class XorEnumeratorTests extends EnumeratorSuite[({ type L[x] = XorT[Eval, Throw
       val error: Throwable = new Exception(message)
       val enumerator = failEnumerator(error).handleErrorWith[Throwable](_ => eav.enumerator)
 
-      enumerator.drain.value.value === Xor.right(eav.values)
+      enumerator.toVector.value.value === Xor.right(eav.values)
     }
   }
 }
@@ -66,50 +66,6 @@ class XorEnumeratorTests extends EnumeratorSuite[({ type L[x] = XorT[Eval, Throw
 class XorIterateeTests extends IterateeErrorSuite[({ type L[x] = XorT[Eval, Throwable, x] })#L, Throwable]
   with XorSuite {
   type XTE[A] = XorT[Eval, Throwable, A]
-
-  /*implicit val monadError: MonadError[VectorIntFoldingIteratee, Throwable] =
-    Iteratee.iterateeMonadError[
-    ({ type L[x] = XorT[Eval, Throwable, x] })#L,
-    Throwable,
-    Vector[Int]
-  ]
-
-  implicit val arbitraryVectorIntFoldingIteratee: Arbitrary[
-    VectorIntFoldingIteratee[Vector[Int]]
-  ] = arbitraryVectorIteratee[({ type L[x] = XorT[Eval, Throwable, x] })#L, Int]
-
-  implicit val eqVectorIntIteratee: Eq[
-    VectorIntFoldingIteratee[Vector[Int]]
-  ] = eqIteratee[XTE, Vector[Int], Vector[Int]]
-
-  implicit val eqXorUnitIteratee: Eq[
-    VectorIntFoldingIteratee[Xor[Throwable, Unit]]
-  ] = eqIteratee[XTE, Vector[Int], Xor[Throwable, Unit]]
-
-  implicit val eqXorVectorIntIteratee: Eq[
-    VectorIntFoldingIteratee[Xor[Throwable, Vector[Int]]]
-  ] = eqIteratee[XTE, Vector[Int], Xor[Throwable, Vector[Int]]]
-
-  implicit val eqXorTVectorInt3Iteratee: Eq[
-    VectorIntFoldingIteratee[(Vector[Int], Vector[Int], Vector[Int])]
-  ] = eqIteratee[XTE, Vector[Int], (Vector[Int], Vector[Int], Vector[Int])]
-
-  implicit val eqXorTVectorInt: Eq[
-    XorT[({ type L[x] = Iteratee[XTE, Vector[Int], x] })#L, Throwable, Vector[Int]]
-  ] = XorT.xorTEq(eqXorVectorIntIteratee)
-
-  implicit val arbitraryVectorIntFunctionIteratee: Arbitrary[
-    VectorIntFoldingIteratee[Vector[Int] => Vector[Int]]
-  ] = arbitraryFunctionIteratee[XTE, Vector[Int]]
-
-  checkAll(
-    s"Iteratee[$monadName, Vector[Int], Vector[Int]]",
-    MonadErrorTests[VectorIntFoldingIteratee, Throwable].monadError[
-      Vector[Int],
-      Vector[Int],
-      Vector[Int]
-    ]
-  )*/
 
   test("failIteratee") {
     check { (eav: EnumeratorAndValues[Int], message: String) =>


### PR DESCRIPTION
These don't really serve any good purpose—it's easy enough to use the enumeratees or iteratees directly.