### PR TITLE
Add filterK to Enumeratee

### DIFF
--- a/core/src/main/scala/io/iteratee/Enumeratee.scala
+++ b/core/src/main/scala/io/iteratee/Enumeratee.scala
@@ -112,6 +112,19 @@ final object Enumeratee extends EnumerateeInstances {
     }
 
   /**
+    * Drop values that do not satisfy a monadic predicate.
+    */
+  final def filterK[F[_], E](p: E => F[Boolean])(implicit F: Monad[F]): Enumeratee[F, E, E] =
+    flatMap { o =>
+      new Enumerator[F, E] {
+        def apply[A](s: Step[F, E, A]): F[Step[F, E, A]] =
+          F.ifM(p(o))(
+            ifTrue  = s.feedEl(o),
+            ifFalse = F.pure(s))
+      }
+    }
+
+  /**
    * Apply the given [[Iteratee]] repeatedly.
    */
   final def sequenceI[F[_], O, I](iteratee: Iteratee[F, O, I])(implicit F: Monad[F]): Enumeratee[F, O, I] =

--- a/core/src/main/scala/io/iteratee/EnumerateeModule.scala
+++ b/core/src/main/scala/io/iteratee/EnumerateeModule.scala
@@ -46,6 +46,13 @@ trait EnumerateeModule[F[_]] {
   final def filter[E](p: E => Boolean)(implicit F: Monad[F]): Enumeratee[F, E, E] = Enumeratee.filter(p)
 
   /**
+    * Drop values that do not satisfy the given monadic predicate.
+    *
+    * @group Enumeratees
+    */
+  final def filterK[E](f: E => F[Boolean])(implicit F: Monad[F]): Enumeratee[F, E, E] = Enumeratee.filterK(f)
+
+  /**
    * Apply the given [[Iteratee]] repeatedly.
    *
    * @group Enumeratees

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
@@ -61,6 +61,15 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     }
   }
 
+  test("filterK") {
+    check { (eav: EnumeratorAndValues[Int]) =>
+      val p:  Int => Boolean    = _ % 2 == 0
+      val fp: Int => F[Boolean] = i => F.pure(p(i))
+
+      eav.enumerator.mapE(filterK(fp)).toVector === F.pure(eav.values.filter(p))
+    }
+  }
+
   test("sequenceI") {
     check { (eav: EnumeratorAndValues[Int]) =>
       Prop.forAll(Gen.posNum[Int]) { n =>


### PR DESCRIPTION
Add a `filterK` method to `Enumeratee` that allows using monadic predicate for filtering elements.

See [gitter discussion](https://gitter.im/travisbrown/iteratee?at=56952ed0b1f439094a07b87e).