### PR TITLE
Add tests for fs2 benchmarks

### DIFF
--- a/benchmark/src/test/scala/io/iteratee/benchmark/InMemoryBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/iteratee/benchmark/InMemoryBenchmarkSpec.scala
@@ -25,4 +25,8 @@ class InMemoryBenchmarkSpec extends FlatSpec {
   it should "correctly calculate the sum using the collections library" in {
     assert(benchmark.sumInts4C === sum)
   }
+
+  it should "correctly calculate the sum using fs2" in {
+    assert(benchmark.sumInts5F === sum)
+  }
 }

--- a/benchmark/src/test/scala/io/iteratee/benchmark/StreamingBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/iteratee/benchmark/StreamingBenchmarkSpec.scala
@@ -25,4 +25,8 @@ class StreamingBenchmarkSpec extends FlatSpec {
   it should "correctly calculate the sum using the collections library" in {
     assert(benchmark.takeLongs4C === taken)
   }
+
+  it should "correctly calculate the sum using fs2" in {
+    assert(benchmark.takeLongs5F === taken)
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -148,6 +148,7 @@ lazy val benchmark = project
   .settings(noPublishSettings)
   .settings(
     libraryDependencies ++= Seq(
+      "co.fs2" %% "fs2-core" % "0.9.0-SNAPSHOT",
       "com.typesafe.play" %% "play-iteratees" % "2.5.0",
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
       "org.scalaz" %% "scalaz-iteratee" % "7.1.7",
@@ -155,9 +156,7 @@ lazy val benchmark = project
     )
   )
   .enablePlugins(JmhPlugin)
-  .dependsOn(core, task, fs2)
-
-lazy val fs2 = ProjectRef(uri("git://github.com/functional-streams-for-scala/fs2.git#topic/redesign"), "core")
+  .dependsOn(core, task)
 
 lazy val publishSettings = Seq(
   releaseCrossBuild := true,


### PR DESCRIPTION
This is a follow-up to #57 that adds tests for the fs2 benchmarks and switches to using the published snapshot.