### PR TITLE
Rename mapK to flatMapF

### DIFF
--- a/core/src/main/scala/io/iteratee/Enumeratee.scala
+++ b/core/src/main/scala/io/iteratee/Enumeratee.scala
@@ -44,7 +44,14 @@ final object Enumeratee extends EnumerateeInstances {
   /**
    * Map a function returning a value in a context over a stream.
    */
+  @deprecated("Use flatMapF", "0.3.0")
   final def mapK[F[_], O, I](f: O => F[I])(implicit F: Monad[F]): Enumeratee[F, O, I] =
+    flatMapF(f)
+
+  /**
+   * Map a function returning a value in a context over a stream.
+   */
+  final def flatMapF[F[_], O, I](f: O => F[I])(implicit F: Monad[F]): Enumeratee[F, O, I] =
     flatMap(o => Enumerator.liftM[F, I](f(o)))
 
   /**

--- a/core/src/main/scala/io/iteratee/EnumerateeModule.scala
+++ b/core/src/main/scala/io/iteratee/EnumerateeModule.scala
@@ -20,7 +20,15 @@ trait EnumerateeModule[F[_]] {
    *
    * @group Enumeratees
    */
-  final def mapK[O, I](f: O => F[I])(implicit F: Monad[F]): Enumeratee[F, O, I] = Enumeratee.mapK(f)
+  @deprecated("Use flatMapF", "0.3.0")
+  final def mapK[O, I](f: O => F[I])(implicit F: Monad[F]): Enumeratee[F, O, I] = Enumeratee.flatMapF(f)
+
+  /**
+   * Map a function returning a value in a context over a stream.
+   *
+   * @group Enumeratees
+   */
+  final def flatMapF[O, I](f: O => F[I])(implicit F: Monad[F]): Enumeratee[F, O, I] = Enumeratee.flatMapF(f)
 
   /**
    * Map a function returning an [[Enumerator]] over a stream and flatten the

--- a/core/src/main/scala/io/iteratee/Enumerator.scala
+++ b/core/src/main/scala/io/iteratee/Enumerator.scala
@@ -16,7 +16,10 @@ abstract class Enumerator[F[_], E] extends Serializable { self =>
 
   final def map[B](f: E => B)(implicit F: Monad[F]): Enumerator[F, B] = mapE(Enumeratee.map(f))
 
-  final def mapK[B](f: E => F[B])(implicit F: Monad[F]): Enumerator[F, B] = mapE(Enumeratee.mapK(f))
+  @deprecated("Use flatMapF", "0.3.0")
+  final def mapK[B](f: E => F[B])(implicit F: Monad[F]): Enumerator[F, B] = flatMapF(f)
+
+  final def flatMapF[B](f: E => F[B])(implicit F: Monad[F]): Enumerator[F, B] = mapE(Enumeratee.flatMapF(f))
 
   final def flatMap[B](f: E => Enumerator[F, B])(implicit F: Monad[F]): Enumerator[F, B] = mapE(Enumeratee.flatMap(f))
 

--- a/core/src/main/scala/io/iteratee/Iteratee.scala
+++ b/core/src/main/scala/io/iteratee/Iteratee.scala
@@ -44,7 +44,14 @@ sealed class Iteratee[F[_], E, A] private[iteratee] (final val state: F[Step[F, 
   /**
    * Map a monadic function over the result of this [[Iteratee]].
    */
+  @deprecated("Use flatMapF", "0.3.0")
   final def mapK[B](f: A => F[B])(implicit F: Monad[F]): Iteratee[F, E, B] =
+    flatMapF(f)
+
+  /**
+   * Map a monadic function over the result of this [[Iteratee]].
+   */
+  final def flatMapF[B](f: A => F[B])(implicit F: Monad[F]): Iteratee[F, E, B] =
     Iteratee.iteratee(F.flatMap(state)(_.bind(a => F.map(f(a))(Step.done[F, E, B](_)))))
 
   /**

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
@@ -17,9 +17,9 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     }
   }
 
-  test("mapK") {
+  test("flatMapF") {
     check { (eav: EnumeratorAndValues[Int]) =>
-      eav.enumerator.mapE(mapK(i => F.pure(i + 1))).toVector === F.pure(eav.values.map(_ + 1))
+      eav.enumerator.mapE(flatMapF(i => F.pure(i + 1))).toVector === F.pure(eav.values.map(_ + 1))
     }
   }
 

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
@@ -163,9 +163,9 @@ abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
     }
   }
 
-  test("mapK") {
+  test("flatMapF") {
     check { (eav: EnumeratorAndValues[Int]) =>
-      eav.enumerator.mapK(i => F.pure(i + 1)).toVector === F.pure(eav.values.map(_ + 1))
+      eav.enumerator.flatMapF(i => F.pure(i + 1)).toVector === F.pure(eav.values.map(_ + 1))
     }
   }
 

--- a/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
@@ -258,9 +258,9 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     }
   }
 
-  test("mapK") {
+  test("flatMapF") {
     check { (eav: EnumeratorAndValues[Int], iteratee: Iteratee[F, Int, Int]) =>
-      eav.enumerator.run(iteratee.mapK(F.pure)) === eav.enumerator.run(iteratee)
+      eav.enumerator.run(iteratee.flatMapF(F.pure)) === eav.enumerator.run(iteratee)
     }
   }
 


### PR DESCRIPTION
This is both clearer and more consistent with e.g. `Kleisli`'s `flatMapF` in Cats.