### PR TITLE
Rename generate to iterateUntil and introduce new generateM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ lazy val root = project.in(file("."))
   .settings(docSettings)
   .settings(noPublishSettings)
   .aggregate(core, coreJS, task, tests, testsJS, benchmark)
-  .dependsOn(core)
+  .dependsOn(core, task)
 
 lazy val coreBase = crossProject.crossType(CrossType.Pure).in(file("core"))
   .settings(

--- a/core/src/main/scala/io/iteratee/Enumerator.scala
+++ b/core/src/main/scala/io/iteratee/Enumerator.scala
@@ -201,35 +201,42 @@ final object Enumerator extends EnumeratorInstances {
     }
 
   /**
-   * An enumerator that iteratively performs an operation until None is generated and returns
-   * the results.
+   * An enumerator that iteratively performs an operation until `None` is
+   * generated and returns the results.
    */
-  final def generate[F[_], E](init: E)(f: E => Option[E])(implicit F: Monad[F]): Enumerator[F, E] =
+  final def iterateUntil[F[_], E](init: E)(f: E => Option[E])(implicit F: Monad[F]): Enumerator[F, E] =
     new Enumerator[F, E] {
       private[this] def loop[A](step: Step[F, E, A], last: Option[E]): F[Step[F, E, A]] =
         last match {
           case Some(last) if !step.isDone => F.flatMap(step.feedEl(last))(loop(_, f(last)))
-          case _ => F.pure(step)
+          case None => F.pure(step)
         }
       final def apply[A](s: Step[F, E, A]): F[Step[F, E, A]] = loop(s, Some(init))
     }
 
   /**
-   * An enumerator that iteratively performs an effectful operation until None is generated and returns
-   * the results.
+   * An enumerator that iteratively performs an effectful operation until `None`
+   * is generated and returns the results.
    */
-  final def generateM[F[_], E](init: E)(f: E => F[Option[E]])(implicit F: Monad[F]): Enumerator[F, E] =
+  final def iterateUntilM[F[_], E](init: E)(f: E => F[Option[E]])(implicit F: Monad[F]): Enumerator[F, E] =
     new Enumerator[F, E] {
-      private[this] def loop[A](step: Step[F, E, A], last: Option[E]): F[Step[F, E, A]] = {
+      private[this] def loop[A](step: Step[F, E, A], last: Option[E]): F[Step[F, E, A]] =
         last match {
           case Some(last) if !step.isDone => F.flatMap(step.feedEl(last))(next => F.flatMap(f(last))(loop(next, _)))
-          case _ => F.pure(step)
+          case None => F.pure(step)
         }
-      }
       final def apply[A](s: Step[F, E, A]): F[Step[F, E, A]] = loop(s, Some(init))
     }
 
-
-
-
+  /**
+   * An enumerator that returns the result of an effectful operation until
+   * `None` is generated.
+   */
+  final def generateM[F[_], E](f: F[Option[E]])(implicit F: Monad[F]): Enumerator[F, E] = new Enumerator[F, E] {
+    final def apply[A](s: Step[F, E, A]): F[Step[F, E, A]] =
+      if (s.isDone) F.pure(s) else F.flatMap(f) {
+        case None => F.pure(s)
+        case Some(e) => F.flatMap(s.feedEl(e))(apply)
+      }
+  }
 }

--- a/core/src/main/scala/io/iteratee/EnumeratorModule.scala
+++ b/core/src/main/scala/io/iteratee/EnumeratorModule.scala
@@ -124,8 +124,8 @@ trait EnumeratorModule[F[_]] {
    *
    * @group Enumerators
    */
-  final def generate[E](init: E)(f: E => Option[E])(implicit F: Monad[F]): Enumerator[F, E] =
-    Enumerator.generate(init)(f)
+  final def iterateUntil[E](init: E)(f: E => Option[E])(implicit F: Monad[F]): Enumerator[F, E] =
+    Enumerator.iterateUntil(init)(f)
 
   /**
    * An enumerator that iteratively performs an effectful operation until None is produced and returns
@@ -133,7 +133,12 @@ trait EnumeratorModule[F[_]] {
    *
    * @group Enumerators
    */
-  final def generateM[E](init: E)(f: E => F[Option[E]])(implicit F: Monad[F]): Enumerator[F, E] =
-    Enumerator.generateM(init)(f)
+  final def iterateUntilM[E](init: E)(f: E => F[Option[E]])(implicit F: Monad[F]): Enumerator[F, E] =
+    Enumerator.iterateUntilM(init)(f)
 
+  /**
+   * An enumerator that returns the result of an effectful operation until
+   * `None` is generated.
+   */
+  final def generateM[E](f: F[Option[E]])(implicit F: Monad[F]): Enumerator[F, E] = Enumerator.generateM(f)
 }

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
@@ -85,25 +85,19 @@ abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
     }
   }
 
-  test("generate") {
-    check { (n: Int, count: Short) =>
-      val enumerator = generate(n){ i => if (i == count){
-        None
-      }else{
-        Some(i + 1)
-      }}
-      enumerator.run(take(count.toInt)) === F.pure(Vector.iterate(n, count.toInt)(_ + 1))
+  test("iterateUntil") {
+    check { (n: Short) =>
+      val count = math.abs(n.toInt)
+      val enumerator = iterateUntil(0)(i => if (i == count) None else Some(i + 1))
+      enumerator.toVector === F.pure((0 to count).toVector)
     }
   }
 
-  test("pure generateM") {
-    check { (n: Int, count: Short) =>
-      val enumerator = generateM(n){ i => F.pure(if (i == count){
-        None
-      }else{
-        Some(i + 1)
-      })}
-      enumerator.run(take(count.toInt)) === F.pure(Vector.iterate(n, count.toInt)(_ + 1))
+  test("pure iterateUntilM") {
+    check { (n: Short) =>
+      val count = math.abs(n.toInt)
+      val enumerator = iterateUntilM(0)(i => F.pure(if (i == count) None else Some(i + 1)))
+      enumerator.toVector === F.pure((0 to count).toVector)
     }
   }
 

--- a/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
@@ -379,7 +379,7 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
   /**
    * Well-behaved iteratees don't inject values into the stream, but if we do
    * end up in this situation, we try to make sure something fairly reasonable
-   * happens (and specifically that flatMap stays associative in as many cases
+   * happens (and specifically that `flatMap` stays associative in as many cases
    * as possible).
    */
   test("successive iteratees that inject values") {

--- a/tests/shared/src/test/scala/io/iteratee/EvalTests.scala
+++ b/tests/shared/src/test/scala/io/iteratee/EvalTests.scala
@@ -12,7 +12,25 @@ class EvalEnumeratorTests extends EnumeratorSuite[Eval] with EvalSuite {
       val action = perform[Int](Eval.always(counter += 1))
       val enumerator = action.append(eav.enumerator).append(action)
 
-      counter === 0 && enumerator.toVector === F.pure(eav.values) && counter === 2
+      counter === 0 && enumerator.toVector === Eval.now(eav.values) && counter === 2
+    }
+  }
+
+  test("generateM") {
+    check { (n: Short) =>
+      val count = math.abs(n.toInt)
+      var counter = 0
+      val enumerator = generateM(
+        Eval.always(
+          if (counter > count) None else Some {
+            val result = counter
+            counter += 1
+            result
+          }
+        )
+      )
+
+      enumerator.toVector === Eval.now((0 to count).toVector) && counter == count + 1
     }
   }
 }


### PR DESCRIPTION
I'm planning an 0.3.0 release and decided that I'd like to rename `generate` and `generateM` to `iterateUntil` and `iterateUntilM` (to avoid the confusing collision with Play's naming). I've also introduced a new `generateM` that works like Play's.

/cc @Crafter6432