### PR TITLE
Add take and drop enumeratees, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
   - 2.10.6
-  - 2.11.7
+  - 2.11.8
 
 jdk:
   - openjdk7

--- a/benchmark/src/main/scala/io/iteratee/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/iteratee/benchmark/Benchmark.scala
@@ -90,7 +90,7 @@ class StreamingBenchmark extends StreamingExampleData {
   val count = 10000
 
   @Benchmark
-  def takeLongs0I: Vector[Long] = longStreamI.run(take(count)).run
+  def takeLongs0I: Vector[Long] = longStreamI.run(takeI(count)).run
 
   @Benchmark
   def takeLongs1S: Vector[Long] = longStreamS.take(count).runLog.run

--- a/core/src/main/scala/io/iteratee/EnumerateeInstances.scala
+++ b/core/src/main/scala/io/iteratee/EnumerateeInstances.scala
@@ -9,7 +9,7 @@ private[iteratee] trait EnumerateeInstances {
     Category[({ type L[x, y] = Enumeratee[F, x, y]})#L] with
     Profunctor[({ type L[x, y] = Enumeratee[F, x, y]})#L] =
     new Category[({ type L[x, y] = Enumeratee[F, x, y]})#L] with Profunctor[({ type L[x, y] = Enumeratee[F, x, y]})#L] {
-      final def id[A]: Enumeratee[F, A, A] = Enumeratee.map[F, A, A](identity)
+      final def id[A]: Enumeratee[F, A, A] = Enumeratee.identity[F, A]
       final def compose[A, B, C](f: Enumeratee[F, B, C], g: Enumeratee[F, A, B]): Enumeratee[F, A, C] = g.andThen(f)
       final def dimap[A, B, C, D](fab: Enumeratee[F, A, B])(f: C => A)(g: B => D): Enumeratee[F, C, D] =
         fab.map(g).contramap(f)

--- a/core/src/main/scala/io/iteratee/EnumerateeModule.scala
+++ b/core/src/main/scala/io/iteratee/EnumerateeModule.scala
@@ -1,7 +1,7 @@
 package io.iteratee
 
 import algebra.Eq
-import cats.Monad
+import cats.{ Applicative, Monad }
 
 /**
  * @groupname Enumeratees Enumeratees
@@ -13,7 +13,7 @@ trait EnumerateeModule[F[_]] {
    *
    * @group Enumeratees
    */
-  final def map[O, I](f: O => I)(implicit F: Monad[F]): Enumeratee[F, O, I] = Enumeratee.map(f)
+  final def map[O, I](f: O => I)(implicit F: Applicative[F]): Enumeratee[F, O, I] = Enumeratee.map(f)
 
   /**
    * Map a function returning a value in a context over a stream.
@@ -39,26 +39,59 @@ trait EnumerateeModule[F[_]] {
   final def flatMap[O, I](f: O => Enumerator[F, I])(implicit F: Monad[F]): Enumeratee[F, O, I] = Enumeratee.flatMap(f)
 
   /**
+   * An [[Enumeratee]] that takes a given number of the first values in a
+   * stream.
+   */
+  final def take[E](n: Int)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.take(n)
+
+  /**
+   * An [[Enumeratee]] that tales values from a stream as long as they satisfy
+   * the given predicate.
+   */
+  final def takeWhile[E](p: E => Boolean)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.takeWhile(p)
+
+  /**
+   * An [[Enumeratee]] that drops a given number of the first values in a
+   * stream.
+   */
+  final def drop[E](n: Int)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.drop(n)
+
+  /**
+   * An [[Enumeratee]] that drops values from a stream as long as they satisfy
+   * the given predicate.
+   */
+  final def dropWhile[E](p: E => Boolean)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.dropWhile(p)
+
+  /**
    * Transform values using a [[scala.PartialFunction]] and drop values that
    * aren't matched.
    *
    * @group Enumeratees
    */
-  final def collect[O, I](pf: PartialFunction[O, I])(implicit F: Monad[F]): Enumeratee[F, O, I] = Enumeratee.collect(pf)
+  final def collect[O, I](pf: PartialFunction[O, I])(implicit F: Applicative[F]): Enumeratee[F, O, I] =
+    Enumeratee.collect(pf)
 
   /**
    * Drop values that do not satisfy the given predicate.
    *
    * @group Enumeratees
    */
-  final def filter[E](p: E => Boolean)(implicit F: Monad[F]): Enumeratee[F, E, E] = Enumeratee.filter(p)
+  final def filter[E](p: E => Boolean)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.filter(p)
 
   /**
     * Drop values that do not satisfy the given monadic predicate.
     *
     * @group Enumeratees
     */
-  final def filterK[E](f: E => F[Boolean])(implicit F: Monad[F]): Enumeratee[F, E, E] = Enumeratee.filterK(f)
+  @deprecated("Use filterF", "0.3.0")
+  final def filterK[E](p: E => F[Boolean])(implicit F: Monad[F]): Enumeratee[F, E, E] = Enumeratee.filterF(p)
+
+  /**
+    * Drop values that do not satisfy the given monadic predicate.
+    *
+    * @group Enumeratees
+    */
+  final def filterF[E](p: E => F[Boolean])(implicit F: Monad[F]): Enumeratee[F, E, E] = Enumeratee.filterF(p)
 
   /**
    * Apply the given [[Iteratee]] repeatedly.
@@ -74,14 +107,14 @@ trait EnumerateeModule[F[_]] {
    * @note Assumes that the stream is sorted.
    * @group Enumeratees
    */
-  final def uniq[E: Eq](implicit F: Monad[F]): Enumeratee[F, E, E] = Enumeratee.uniq
+  final def uniq[E: Eq](implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.uniq[F, E]
 
   /**
    * Zip with the number of elements that have been encountered.
    *
    * @group Enumeratees
    */
-  final def zipWithIndex[E](implicit F: Monad[F]): Enumeratee[F, E, (E, Long)] = Enumeratee.zipWithIndex
+  final def zipWithIndex[E](implicit F: Applicative[F]): Enumeratee[F, E, (E, Long)] = Enumeratee.zipWithIndex
 
   /**
    * Split the stream into groups of a given length.

--- a/core/src/main/scala/io/iteratee/EnumerateeModule.scala
+++ b/core/src/main/scala/io/iteratee/EnumerateeModule.scala
@@ -41,24 +41,32 @@ trait EnumerateeModule[F[_]] {
   /**
    * An [[Enumeratee]] that takes a given number of the first values in a
    * stream.
+   *
+   * @group Enumeratees
    */
   final def take[E](n: Int)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.take(n)
 
   /**
    * An [[Enumeratee]] that tales values from a stream as long as they satisfy
    * the given predicate.
+   *
+   * @group Enumeratees
    */
   final def takeWhile[E](p: E => Boolean)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.takeWhile(p)
 
   /**
    * An [[Enumeratee]] that drops a given number of the first values in a
    * stream.
+   *
+   * @group Enumeratees
    */
   final def drop[E](n: Int)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.drop(n)
 
   /**
    * An [[Enumeratee]] that drops values from a stream as long as they satisfy
    * the given predicate.
+   *
+   * @group Enumeratees
    */
   final def dropWhile[E](p: E => Boolean)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.dropWhile(p)
 

--- a/core/src/main/scala/io/iteratee/EnumeratorModule.scala
+++ b/core/src/main/scala/io/iteratee/EnumeratorModule.scala
@@ -139,6 +139,8 @@ trait EnumeratorModule[F[_]] {
   /**
    * An enumerator that returns the result of an effectful operation until
    * `None` is generated.
+   *
+   * @group Enumerators
    */
   final def generateM[E](f: F[Option[E]])(implicit F: Monad[F]): Enumerator[F, E] = Enumerator.generateM(f)
 }

--- a/core/src/main/scala/io/iteratee/Iteratee.scala
+++ b/core/src/main/scala/io/iteratee/Iteratee.scala
@@ -130,13 +130,20 @@ final object Iteratee extends IterateeInstances {
   ): Iteratee[F, E, A] = fromStep(Step.cont(es => ifInput(es).state, ifEnd))
 
   /**
+   * Create a new completed [[Iteratee]] with the given result.
+   *
+   * @group Constructors
+   */
+  final def done[F[_]: Applicative, E, A](value: A): Iteratee[F, E, A] = fromStep(Step.done(value))
+
+  /**
    * Create a new completed [[Iteratee]] with the given result and leftover
    * input.
    *
    * @group Constructors
    */
-  final def done[F[_]: Applicative, E, A](value: A, remaining: Vector[E] = Vector.empty): Iteratee[F, E, A] =
-    fromStep(Step.done(value, remaining))
+  final def doneWithLeftovers[F[_]: Applicative, E, A](value: A, remaining: Vector[E]): Iteratee[F, E, A] =
+    fromStep(Step.doneWithLeftovers(value, remaining))
 
   /**
    * Create an [[Iteratee]] from a [[io.iteratee.internal.Step]] in a context.

--- a/core/src/main/scala/io/iteratee/IterateeModule.scala
+++ b/core/src/main/scala/io/iteratee/IterateeModule.scala
@@ -29,9 +29,8 @@ trait IterateeModule[F[_]] {
    *
    * @group Constructors
    */
-  final def done[E, A](value: A, remaining: Vector[E] = Vector.empty)
-    (implicit F: Applicative[F]): Iteratee[F, E, A] =
-      Iteratee.done(value, remaining)
+  final def done[E, A](value: A, remaining: Vector[E] = Vector.empty)(implicit F: Applicative[F]): Iteratee[F, E, A] =
+    Iteratee.doneWithLeftovers(value, remaining)
 
   /**
    * @group Helpers
@@ -123,8 +122,7 @@ trait IterateeModule[F[_]] {
    *
    * @group Iteratees
    */
-  final def take[E](n: Int)(implicit F: Applicative[F]): Iteratee[F, E, Vector[E]] =
-    Iteratee.take(n)
+  final def takeI[E](n: Int)(implicit F: Applicative[F]): Iteratee[F, E, Vector[E]] = Iteratee.take(n)
 
   /**
    * An [[Iteratee]] that returns values from a stream as long as they satisfy
@@ -132,7 +130,7 @@ trait IterateeModule[F[_]] {
    *
    * @group Iteratees
    */
-  final def takeWhile[E](p: E => Boolean)(implicit F: Applicative[F]): Iteratee[F, E, Vector[E]] =
+  final def takeWhileI[E](p: E => Boolean)(implicit F: Applicative[F]): Iteratee[F, E, Vector[E]] =
     Iteratee.takeWhile(p)
 
   /**
@@ -140,7 +138,7 @@ trait IterateeModule[F[_]] {
    *
    * @group Iteratees
    */
-  final def drop[E](n: Int)(implicit F: Applicative[F]): Iteratee[F, E, Unit] = Iteratee.drop(n)
+  final def dropI[E](n: Int)(implicit F: Applicative[F]): Iteratee[F, E, Unit] = Iteratee.drop(n)
 
   /**
    * An [[Iteratee]] that drops values from a stream as long as they satisfy the
@@ -148,8 +146,7 @@ trait IterateeModule[F[_]] {
    *
    * @group Iteratees
    */
-  final def dropWhile[E](p: E => Boolean)(implicit F: Applicative[F]): Iteratee[F, E, Unit] =
-    Iteratee.dropWhile(p)
+  final def dropWhileI[E](p: E => Boolean)(implicit F: Applicative[F]): Iteratee[F, E, Unit] = Iteratee.dropWhile(p)
 
   /**
    * An [[Iteratee]] that collects all inputs in reverse order.

--- a/core/src/main/scala/io/iteratee/internal/Input.scala
+++ b/core/src/main/scala/io/iteratee/internal/Input.scala
@@ -48,7 +48,7 @@ final object Input  {
     def onChunk(h1: E, h2: E, t: Vector[E]): Z
   }
 
-  private[internal] final def fromVectorUnsafe[E](es: Vector[E]): Input[E] =
+  private[iteratee] final def fromVectorUnsafe[E](es: Vector[E]): Input[E] =
     if (es.size == 1) el(es(0)) else chunk(es(0), es(1), es.drop(2))
 
   private[internal] final def fromPair[E](e: E, es: Vector[E]): Input[E] =

--- a/core/src/main/scala/io/iteratee/internal/Step.scala
+++ b/core/src/main/scala/io/iteratee/internal/Step.scala
@@ -140,12 +140,27 @@ final object Step { self =>
    *
    * @group Constructors
    */
-  final def done[F[_]: Applicative, E, A](value: A, remaining: Vector[E] = Vector.empty): Step[F, E, A] =
+  final def done[F[_]: Applicative, E, A](value: A): Step[F, E, A] = new NoLeftovers(value)
+
+  /**
+   * Create a new completed [[Step]] with the given result and leftover input.
+   *
+   * @group Constructors
+   */
+  final def doneWithLeftovers[F[_]: Applicative, E, A](value: A, remaining: Vector[E]): Step[F, E, A] =
     remaining match {
       case Vector() => new NoLeftovers(value)
       case Vector(e) => new WithLeftovers(value, Input.el(e))
       case h1 +: h2 +: t => new WithLeftovers(value, Input.chunk(h1, h2, t))
     }
+
+  /**
+   * Create a new completed [[Step]] with the given result and leftover [[Input]].
+   *
+   * @group Constructors
+   */
+  final def doneWithLeftoverInput[F[_]: Applicative, E, A](value: A, remaining: Input[E]): Step[F, E, A] =
+    new WithLeftovers(value, remaining)
 
   /**
    * Lift a monadic value into a [[Step]].

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
@@ -45,6 +45,12 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     }
   }
 
+  test("take that ends mid-chunk") {
+    check { (v: Vector[Int]) =>
+      enumVector(v).mapE(take(v.size - 1)).toVector === F.pure(v.dropRight(1))
+    }
+  }
+
   test("take with wrap") {
     check { (eav: EnumeratorAndValues[Int], n: Int) =>
       val eavNew = eav.copy(enumerator = take[Int](n).wrap(eav.enumerator))

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
@@ -71,6 +71,12 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     }
   }
 
+  test("drop with one left over") {
+    check { (v: Vector[Int]) =>
+      enumVector(v).mapE(drop(v.size - 1)).toVector === F.pure(v.lastOption.toVector)
+    }
+  }
+
   test("dropWhile") {
     check { (eav: EnumeratorAndValues[Int], n: Int) =>
       eav.resultWithLeftovers(consume[Int].through(dropWhile(_ < n))) ===

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
@@ -69,19 +69,19 @@ abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
 
   test("repeat") {
     check { (i: Int, count: Short) =>
-      repeat(i).run(take(count.toInt)) === F.pure(Vector.fill(count.toInt)(i))
+      repeat(i).run(takeI(count.toInt)) === F.pure(Vector.fill(count.toInt)(i))
     }
   }
 
   test("iterate") {
     check { (n: Int, count: Short) =>
-      iterate(n)(_ + 1).run(take(count.toInt)) === F.pure(Vector.iterate(n, count.toInt)(_ + 1))
+      iterate(n)(_ + 1).run(takeI(count.toInt)) === F.pure(Vector.iterate(n, count.toInt)(_ + 1))
     }
   }
 
   test("pure iterateM") {
     check { (n: Int, count: Short) =>
-      iterateM(n)(i => F.pure(i + 1)).run(take(count.toInt)) === F.pure(Vector.iterate(n, count.toInt)(_ + 1))
+      iterateM(n)(i => F.pure(i + 1)).run(takeI(count.toInt)) === F.pure(Vector.iterate(n, count.toInt)(_ + 1))
     }
   }
 

--- a/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
@@ -152,14 +152,14 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
        * ScalaCheck is likely to run into.
        */
       (n != Int.MaxValue) ==> {
-        eav.resultWithLeftovers(take[Int](n)) === F.pure((eav.values.take(n), eav.values.drop(n)))
+        eav.resultWithLeftovers(takeI[Int](n)) === F.pure((eav.values.take(n), eav.values.drop(n)))
       }
     }
   }
 
   test("takeWhile") {
     check { (eav: EnumeratorAndValues[Int], n: Int) =>
-      eav.resultWithLeftovers(takeWhile(_ < n)) === F.pure(eav.values.span(_ < n))
+      eav.resultWithLeftovers(takeWhileI(_ < n)) === F.pure(eav.values.span(_ < n))
     }
   }
 
@@ -170,20 +170,20 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
        * ScalaCheck is likely to run into.
        */
       (n != Int.MaxValue) ==> {
-        eav.resultWithLeftovers(drop[Int](n)) === F.pure(((), eav.values.drop(n)))
+        eav.resultWithLeftovers(dropI[Int](n)) === F.pure(((), eav.values.drop(n)))
       }
     }
   }
 
   test("dropWhile") {
     check { (eav: EnumeratorAndValues[Int], n: Int) =>
-      eav.resultWithLeftovers(dropWhile(_ < n)) === F.pure(((), eav.values.dropWhile(_ < n)))
+      eav.resultWithLeftovers(dropWhileI(_ < n)) === F.pure(((), eav.values.dropWhile(_ < n)))
     }
   }
 
   test("dropWhile with nothing left in chunk") {
     val iteratee = for {
-      _ <- dropWhile[Int](_ < 100)
+      _ <- dropWhileI[Int](_ < 100)
       r <- consume
     } yield r
     enumVector(Vector(1, 2, 3)).run(iteratee) === F.pure(Vector(1, 2, 3))
@@ -295,14 +295,14 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
       (m != Int.MaxValue && n != Int.MaxValue) ==> {
         val result = ((eav.values.take(m), eav.values.take(n)), eav.values.drop(math.max(m, n)))
 
-        eav.resultWithLeftovers(take[Int](m).zip(take[Int](n))) === F.pure(result)
+        eav.resultWithLeftovers(takeI[Int](m).zip(takeI[Int](n))) === F.pure(result)
       }
     }
   }
 
   test("zip where leftover sizes must be compared") {
     check { (eav: EnumeratorAndValues[Int]) =>
-      val iteratee = take[Int](2).zip(take(3))
+      val iteratee = takeI[Int](2).zip(takeI(3))
 
       val result = ((eav.values.take(2), eav.values.take(3)), eav.values.drop(3))
 
@@ -313,8 +313,8 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
   test("zip with single leftovers") {
     val es = Vector(1, 2, 3, 4)
     val enumerator = enumVector(es)
-    val iteratee1 = take[Int](2).zip(take(3)).zip(take(4))
-    val iteratee2 = take[Int](2).zip(take(3)).zip(consume)
+    val iteratee1 = takeI[Int](2).zip(takeI(3)).zip(takeI(4))
+    val iteratee2 = takeI[Int](2).zip(takeI(3)).zip(consume)
     val result = ((es.take(2), es.take(3)), es)
 
     assert(

--- a/tests/shared/src/test/scala/io/iteratee/XorTests.scala
+++ b/tests/shared/src/test/scala/io/iteratee/XorTests.scala
@@ -40,7 +40,7 @@ class XorEnumeratorTests extends EnumeratorSuite[({ type L[x] = XorT[Eval, Throw
       val enumerator = eav.enumerator.ensure(action)
       val n = math.max(0, eav.values.size - 2)
 
-      counter == 0 && enumerator.run(take(n)) === F.pure(eav.values.take(n)) && counter === 1
+      counter == 0 && enumerator.run(takeI(n)) === F.pure(eav.values.take(n)) && counter === 1
     }
   }
 


### PR DESCRIPTION
This pull request makes a fairly large number of changes, including the following:

* `filterK` is not deprecated in favor of `filterF` for consistency.
* The helper classes in `Enumeratee` are reworked a bit.
* Unnecessarily restrictive constraints on some enumeratees are relaxed (e.g. `map` now only requires `Applicative`, not `Monad`.
* There are now `take`, `takeWhile`, `drop`, and `dropWhile` enumeratees.
* The `take`, etc. methods that returned iteratees in modules are renamed to `takeI` to avoid collisions with the new (preferred) iteratee methods.
* There are some new methods for constructing `Step` values.