### PR TITLE
Fix #76, more efficient length iteratee

### DIFF
--- a/core/src/main/scala/io/iteratee/EnumerateeModule.scala
+++ b/core/src/main/scala/io/iteratee/EnumerateeModule.scala
@@ -44,7 +44,7 @@ trait EnumerateeModule[F[_]] {
    *
    * @group Enumeratees
    */
-  final def take[E](n: Int)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.take(n)
+  final def take[E](n: Long)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.take(n)
 
   /**
    * An [[Enumeratee]] that tales values from a stream as long as they satisfy
@@ -60,7 +60,7 @@ trait EnumerateeModule[F[_]] {
    *
    * @group Enumeratees
    */
-  final def drop[E](n: Int)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.drop(n)
+  final def drop[E](n: Long)(implicit F: Applicative[F]): Enumeratee[F, E, E] = Enumeratee.drop(n)
 
   /**
    * An [[Enumeratee]] that drops values from a stream as long as they satisfy

--- a/core/src/main/scala/io/iteratee/Iteratee.scala
+++ b/core/src/main/scala/io/iteratee/Iteratee.scala
@@ -282,11 +282,11 @@ final object Iteratee extends IterateeInstances {
     fold[F, A, List[A]](Nil)((acc, e) => e :: acc)
 
   /**
-   * An [[Iteratee]] that combines values using an [[algebra.Monoid]] instance.
+   * An [[Iteratee]] that counts the number of values in a stream.
    *
    * @group Collection
    */
-  final def length[F[_]: Applicative, E]: Iteratee[F, E, Int] = fold(0)((a, _) => a + 1)
+  final def length[F[_]: Applicative, E]: Iteratee[F, E, Long] = fromStep(Step.length[F, E])
 
   /**
    * An [[Iteratee]] that combines values using an [[algebra.Monoid]] instance.

--- a/core/src/main/scala/io/iteratee/IterateeModule.scala
+++ b/core/src/main/scala/io/iteratee/IterateeModule.scala
@@ -160,7 +160,7 @@ trait IterateeModule[F[_]] {
    *
    * @group Iteratees
    */
-  final def length[E](implicit F: Applicative[F]): Iteratee[F, E, Int] = Iteratee.length
+  final def length[E](implicit F: Applicative[F]): Iteratee[F, E, Long] = Iteratee.length
 
   /**
    * An [[Iteratee]] that combines values using an [[algebra.Monoid]] instance.

--- a/core/src/main/scala/io/iteratee/internal/Step.scala
+++ b/core/src/main/scala/io/iteratee/internal/Step.scala
@@ -269,12 +269,25 @@ final object Step { self =>
   }
 
   /**
+   * A [[Step]] that counts the number of values in a stream.
+   *
+   * @group Collection
+   */
+  final def length[F[_]: Applicative, A]: Step[F, A, Long] = new LengthCont(0L)
+
+  private[this] final class LengthCont[F[_], E](acc: Long)(implicit F: Applicative[F])
+    extends PureCont.WithValue[F, E, Long](acc) {
+    final def onEl(e: E): Step[F, E, Long] = new LengthCont(acc + 1L)
+    final def onChunk(h1: E, h2: E, t: Vector[E]): Step[F, E, Long] = new LengthCont(acc + t.size.toLong + 2L)
+  }
+
+  /**
    * A [[Step]] that returns a given number of the first values in a stream.
    *
    * @group Collection
    */
-  final def take[F[_]: Applicative, A](n: Int): Step[F, A, Vector[A]] =
-    if (n <= 0) done[F, A, Vector[A]](Vector.empty) else new TakeCont(Vector.empty, n)
+  final def take[F[_]: Applicative, E](n: Int): Step[F, E, Vector[E]] =
+    if (n <= 0) done[F, E, Vector[E]](Vector.empty) else new TakeCont(Vector.empty, n)
 
   private[this] final class TakeCont[F[_], E](acc: Vector[E], n: Int)(implicit F: Applicative[F])
     extends PureCont.WithValue[F, E, Vector[E]](acc) {

--- a/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
@@ -205,7 +205,7 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
 
   test("length") {
     check { (eav: EnumeratorAndValues[Int]) =>
-      eav.resultWithLeftovers(length) === F.pure((eav.values.size, Vector.empty))
+      eav.resultWithLeftovers(length) === F.pure((eav.values.size.toLong, Vector.empty))
     }
   }
 
@@ -280,7 +280,7 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
 
   test("zip") {
     check { (eav: EnumeratorAndValues[Int]) =>
-      val result = ((eav.values.sum, eav.values.size), Vector.empty)
+      val result = ((eav.values.sum, eav.values.size.toLong), Vector.empty)
 
       eav.resultWithLeftovers(sum[Int].zip(length)) === F.pure(result)
     }


### PR DESCRIPTION
`Iteratee.length` now returns a `Long` and is faster for chunked streams.