### PR TITLE
Use future pool when working with Twitter futures

### DIFF
--- a/tests/jvm/src/it/scala/io/iteratee/task/TaskFileModuleSuite.scala
+++ b/tests/jvm/src/it/scala/io/iteratee/task/TaskFileModuleSuite.scala
@@ -7,5 +7,5 @@ import scalaz.concurrent.Task
 class TaskFileModuleSuite extends FileModuleSuite[Task] with TaskModule {
   def monadName: String = "Task"
 
-  implicit def eqF[A: Eq]: Eq[Task[A]] = Eq.by(_.attemptRun.toEither)
+  implicit def eqF[A: Eq]: Eq[Task[A]] = Eq.by(_.unsafePerformSyncAttempt.toEither)
 }

--- a/tests/jvm/src/it/scala/io/iteratee/twitter/TwitterFileModuleSuite.scala
+++ b/tests/jvm/src/it/scala/io/iteratee/twitter/TwitterFileModuleSuite.scala
@@ -5,7 +5,7 @@ import com.twitter.conversions.time._
 import io.catbird.util.Rerunnable
 import io.iteratee.tests.files.FileModuleSuite
 
-class TwitterFileModuleSuite extends FileModuleSuite[Rerunnable] with TwitterModule {
+class TwitterFileModuleSuite extends FileModuleSuite[Rerunnable] with DefaultFuturePoolTwitterModule {
   def monadName: String = "Rerunnable"
 
   implicit def eqF[A: Eq]: Eq[Rerunnable[A]] = Rerunnable.rerunnableEqWithFailure[A](2.seconds)

--- a/tests/jvm/src/test/scala/io/iteratee/twitter/RerunnableTests.scala
+++ b/tests/jvm/src/test/scala/io/iteratee/twitter/RerunnableTests.scala
@@ -5,7 +5,7 @@ import com.twitter.conversions.time._
 import io.catbird.util.Rerunnable
 import io.iteratee.tests.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, ModuleSuite, eqThrowable }
 
-trait RerunnableSuite extends ModuleSuite[Rerunnable] with TwitterModule {
+trait RerunnableSuite extends ModuleSuite[Rerunnable] with DefaultFuturePoolTwitterModule {
   def monadName: String = "Rerunnable"
 
   implicit def eqF[A: Eq]: Eq[Rerunnable[A]] = Rerunnable.rerunnableEqWithFailure[A](2.seconds)

--- a/twitter/src/main/scala/io/iteratee/twitter/package.scala
+++ b/twitter/src/main/scala/io/iteratee/twitter/package.scala
@@ -1,3 +1,3 @@
 package io.iteratee
 
-package object twitter extends TwitterModule
+package object twitter extends DefaultFuturePoolTwitterModule


### PR DESCRIPTION
In the previous version of iteratee-twitter, `Future.apply` was used to capture effects. This is now configurable, with the default future pool being used by default.

This PR also includes a drive-by fix for a deprecated Scalaz method.