### PR TITLE
Don't export Cats instances for Monix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ often likely to be a simpler, faster solution.
 
 The initial performance benchmarks look promising. For example, here are the throughput results for
 summing a sequence of numbers with this library and Scalaz's `Task` (`IS`), this library and Twitter
-futures (`IR`), this library and [Monix][monix]'s `Task` ('IM'), Scalaz Stream (`S`),
+futures (`IR`), this library and [Monix][monix]'s `Task` (`IM`), Scalaz Stream (`S`),
 scalaz-iteratee (`Z`), [play-iteratee][play-iteratee] (`P`), the collections library (`C`), and fs2
 (`F`). Higher numbers are better.
 

--- a/benchmark/src/test/scala/io/iteratee/benchmark/StreamingBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/iteratee/benchmark/StreamingBenchmarkSpec.scala
@@ -1,6 +1,7 @@
 package io.iteratee.benchmark
 
 import org.scalatest.FlatSpec
+import scala.Predef.intWrapper
 
 class StreamingBenchmarkSpec extends FlatSpec {
   val benchmark: StreamingBenchmark = new StreamingBenchmark

--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,7 @@ lazy val scalaz = project
   )
   .settings(allSettings)
   .settings(
-    libraryDependencies += "org.scalaz" %% "scalaz-concurrent" % "7.2.2"
+    libraryDependencies += "org.scalaz" %% "scalaz-concurrent" % "7.2.4"
   ).dependsOn(core, files)
 
 lazy val monixBase = crossProject.in(file("monix"))
@@ -191,11 +191,11 @@ lazy val benchmark = project
   .settings(noPublishSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "co.fs2" %% "fs2-core" % "0.9.0-M1",
-      "com.typesafe.play" %% "play-iteratees" % "2.5.0",
+      "co.fs2" %% "fs2-core" % "0.9.0-M6",
+      "com.typesafe.play" %% "play-iteratees" % "2.6.0",
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
-      "org.scalaz" %% "scalaz-iteratee" % "7.2.2",
-      "org.scalaz.stream" %% "scalaz-stream" % "0.8.1a"
+      "org.scalaz" %% "scalaz-iteratee" % "7.2.4",
+      "org.scalaz.stream" %% "scalaz-stream" % "0.8.3a"
     )
   )
   .enablePlugins(JmhPlugin)

--- a/monix/js/src/main/scala/io/iteratee/monix/MonixModule.scala
+++ b/monix/js/src/main/scala/io/iteratee/monix/MonixModule.scala
@@ -2,10 +2,10 @@ package io.iteratee.monix
 
 import cats.MonadError
 import io.iteratee.{EnumerateeModule, EnumeratorErrorModule, IterateeErrorModule, Module}
-import monix.cats.{AllInstances => MonixInstances}
+import monix.cats._
 import monix.eval.Task
 
-trait MonixModule extends MonixInstances with Module[Task]
+trait MonixModule extends Module[Task]
   with EnumerateeModule[Task]
   with EnumeratorErrorModule[Task, Throwable] with IterateeErrorModule[Task, Throwable] {
   final type M[f[_]] = MonadError[f, Throwable]

--- a/monix/jvm/src/main/scala/io/iteratee/monix/MonixModule.scala
+++ b/monix/jvm/src/main/scala/io/iteratee/monix/MonixModule.scala
@@ -4,9 +4,9 @@ import cats.MonadError
 import io.iteratee.{ EnumerateeModule, EnumeratorErrorModule, IterateeErrorModule, Module }
 import io.iteratee.files.FileModule
 import monix.eval.Task
-import monix.cats.{AllInstances => MonixInstances}
+import monix.cats._
 
-trait MonixModule extends MonixInstances with Module[Task]
+trait MonixModule extends Module[Task]
   with EnumerateeModule[Task]
   with EnumeratorErrorModule[Task, Throwable] with IterateeErrorModule[Task, Throwable]
   with FileModule[Task] {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,6 +8,7 @@ resolvers ++= Seq(
   "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 )
 
+addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
@@ -18,4 +19,4 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.10")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.2.0")
 addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.14")
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.7")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.11")

--- a/tests/jvm/src/it/scala/io/iteratee/monix/MonixFileModuleSuite.scala
+++ b/tests/jvm/src/it/scala/io/iteratee/monix/MonixFileModuleSuite.scala
@@ -3,6 +3,7 @@ package io.iteratee.monix
 import cats.Eq
 import cats.data.Xor
 import io.iteratee.tests.files.FileModuleSuite
+import monix.cats._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import scala.concurrent.Await

--- a/tests/jvm/src/test/scala/io/iteratee/monix/MonixTests.scala
+++ b/tests/jvm/src/test/scala/io/iteratee/monix/MonixTests.scala
@@ -3,6 +3,7 @@ package io.iteratee.monix
 import cats.Eq
 import cats.data.Xor
 import io.iteratee.tests.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, ModuleSuite, eqThrowable }
+import monix.cats._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import scala.concurrent.Await


### PR DESCRIPTION
Avoids collisions between Cats instances for Monix's `Task` (see [Gitter](https://gitter.im/typelevel/cats?at=579782133383eb622144e9ff)).