### PR TITLE
Don't fork in captureEffect

### DIFF
--- a/scalaz/src/main/scala/io/iteratee/scalaz/ScalazModule.scala
+++ b/scalaz/src/main/scala/io/iteratee/scalaz/ScalazModule.scala
@@ -13,5 +13,5 @@ trait ScalazModule extends ScalazInstances with Module[Task]
 
   final protected val F: MonadError[Task, Throwable] = scalazTaskMonadError
 
-  final protected def captureEffect[A](a: => A): Task[A] = Task(a)
+  final protected def captureEffect[A](a: => A): Task[A] = Task.delay(a)
 }

--- a/twitter/src/main/scala/io/iteratee/twitter/TwitterModule.scala
+++ b/twitter/src/main/scala/io/iteratee/twitter/TwitterModule.scala
@@ -22,6 +22,10 @@ trait TwitterModule extends Module[Rerunnable]
   }
 }
 
+trait DefaultTwitterModule extends TwitterModule {
+  protected final def toFuture[A](a: => A): Future[A] = Future(a)
+}
+
 trait DefaultFuturePoolTwitterModule extends TwitterModule {
   private[this] val futurePool: FuturePool = FuturePool.unboundedPool
 

--- a/twitter/src/main/scala/io/iteratee/twitter/package.scala
+++ b/twitter/src/main/scala/io/iteratee/twitter/package.scala
@@ -1,3 +1,3 @@
 package io.iteratee
 
-package object twitter extends DefaultFuturePoolTwitterModule
+package object twitter extends DefaultTwitterModule


### PR DESCRIPTION
I know this code is likely to change soon, anyway, but this is a small fix that follows e.g. the behavior in scalaz-stream.