### PR TITLE
Rename mapE and run

### DIFF
--- a/benchmark/src/main/scala/io/iteratee/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/iteratee/benchmark/Benchmark.scala
@@ -61,10 +61,10 @@ class StreamingExampleData extends IterateeBenchmark {
 @OutputTimeUnit(TimeUnit.SECONDS)
 class InMemoryBenchmark extends InMemoryExampleData {
   @Benchmark
-  def sumInts0IS: Int = intsI.run(i.Iteratee.sum).unsafePerformSync
+  def sumInts0IS: Int = intsI.into(i.Iteratee.sum).unsafePerformSync
 
   @Benchmark
-  def sumInts1IR: Int = AwaitT.result(intsR.run(i.Iteratee.sum).run, DurationT.Top)
+  def sumInts1IR: Int = AwaitT.result(intsR.into(i.Iteratee.sum).run, DurationT.Top)
 
   @Benchmark
   def sumInts3S: Int = intsS.sum.runLastOr(sys.error("Impossible")).unsafePerformSync
@@ -96,10 +96,10 @@ class StreamingBenchmark extends StreamingExampleData {
   val count = 10000
 
   @Benchmark
-  def takeLongs0IS: Vector[Long] = longStreamI.run(i.Iteratee.take(count)).unsafePerformSync
+  def takeLongs0IS: Vector[Long] = longStreamI.into(i.Iteratee.take(count)).unsafePerformSync
 
   @Benchmark
-  def takeLongs1IR: Vector[Long] = AwaitT.result(longStreamR.run(i.Iteratee.take(count)).run, DurationT.Top)
+  def takeLongs1IR: Vector[Long] = AwaitT.result(longStreamR.into(i.Iteratee.take(count)).run, DurationT.Top)
 
   @Benchmark
   def takeLongs3S: Vector[Long] = longStreamS.take(count).runLog.unsafePerformSync

--- a/benchmark/src/main/scala/io/iteratee/benchmark/FileModuleBenchmark.scala
+++ b/benchmark/src/main/scala/io/iteratee/benchmark/FileModuleBenchmark.scala
@@ -41,17 +41,17 @@ class FileModuleBenchmark extends ScalazInstances {
   }
 
   @Benchmark
-  def avgWordLengthTR: Double = AwaitT.result(linesTR.flatMap(words[Rerunnable]).run(avgLen).run, DurationT.Top)
+  def avgWordLengthTR: Double = AwaitT.result(linesTR.flatMap(words[Rerunnable]).into(avgLen).run, DurationT.Top)
 
   @Benchmark
-  def avgWordLengthTF: Double = AwaitT.result(linesTF.flatMap(words[FutureT]).run(avgLen), DurationT.Top)
+  def avgWordLengthTF: Double = AwaitT.result(linesTF.flatMap(words[FutureT]).into(avgLen), DurationT.Top)
 
   @Benchmark
-  def avgWordLengthTT: Double = linesTT.flatMap(words[TryT]).run(avgLen).get
+  def avgWordLengthTT: Double = linesTT.flatMap(words[TryT]).into(avgLen).get
 
   @Benchmark
-  def avgWordLengthS: Double = linesS.flatMap(words[Task]).run(avgLen).unsafePerformSync
+  def avgWordLengthS: Double = linesS.flatMap(words[Task]).into(avgLen).unsafePerformSync
 
   @Benchmark
-  def avgWordLengthTTF: Double = linesTTF.flatMap(words[FreeTryModule.FreeTry]).run(avgLen).runTailRec.get
+  def avgWordLengthTTF: Double = linesTTF.flatMap(words[FreeTryModule.FreeTry]).into(avgLen).runTailRec.get
 }

--- a/core/src/main/scala/io/iteratee/Enumeratee.scala
+++ b/core/src/main/scala/io/iteratee/Enumeratee.scala
@@ -7,7 +7,7 @@ abstract class Enumeratee[F[_], O, I] extends Serializable { self =>
   def apply[A](step: Step[F, I, A]): F[Step[F, O, Step[F, I, A]]]
 
   final def wrap(enum: Enumerator[F, O])(implicit F: FlatMap[F]): Enumerator[F, I] = new Enumerator[F, I] {
-    final def apply[A](s: Step[F, I, A]): F[Step[F, I, A]] = F.flatMap(self(s))(enum.runStep)
+    final def apply[A](s: Step[F, I, A]): F[Step[F, I, A]] = F.flatMap(self(s))(enum.intoStep)
   }
 
   final def andThen[J](other: Enumeratee[F, I, J])(implicit F: Monad[F]): Enumeratee[F, O, J] = other.compose(self)
@@ -389,7 +389,7 @@ final object Enumeratee extends EnumerateeInstances {
         F.flatMap(Iteratee.head[F, E1].state)(
           _.bind {
             case Some(e) => F.flatMap(
-              F.flatMap(Enumeratee.map[F, E2, (E1, E2)]((e, _)).apply(step))(e2.runStep)
+              F.flatMap(Enumeratee.map[F, E2, (E1, E2)]((e, _)).apply(step))(e2.intoStep)
             )(loop)
             case None => F.pure(Step.done(step))
           }

--- a/tests/jvm/src/main/scala/io/iteratee/tests/files/FileModuleSuite.scala
+++ b/tests/jvm/src/main/scala/io/iteratee/tests/files/FileModuleSuite.scala
@@ -14,7 +14,7 @@ abstract class FileModuleSuite[F[_]: Monad] extends ModuleSuite[F] {
     val txt = new File(getClass.getResource("/io/iteratee/examples/pg/11231/11231.txt").toURI)
     val enumerator = readLines(txt).flatMap(line => enumVector(line.trim.split("\\s+").toVector))
 
-    assert(enumerator.run(length) === F.pure(17973))
+    assert(enumerator.into(length) === F.pure(17973))
   }
 
   it should "work with an iteratee that stops early" in {
@@ -22,7 +22,7 @@ abstract class FileModuleSuite[F[_]: Monad] extends ModuleSuite[F] {
     val result = "The Project Gutenberg EBook of Bartleby, The Scrivener, by Herman Melville"
     val enumerator = readLines(txt)
 
-    assert(enumerator.run(head) === F.pure(Some(result)))
+    assert(enumerator.into(head) === F.pure(Some(result)))
   }
 
   "readLinesFromStream" should "enumerate text lines from a stream" in {
@@ -30,14 +30,14 @@ abstract class FileModuleSuite[F[_]: Monad] extends ModuleSuite[F] {
     val stream = new FileInputStream(txt)
     val enumerator = readLinesFromStream(stream).flatMap(line => enumVector(line.trim.split("\\s+").toVector))
 
-    assert(enumerator.run(length) === F.pure(17973))
+    assert(enumerator.into(length) === F.pure(17973))
   }
 
   "readBytes" should "enumerate bytes from a file" in {
     val txt = new File(getClass.getResource("/io/iteratee/examples/pg/11231/11231.txt").toURI)
     val enumerator = readBytes(txt).flatMap(bytes => enumVector(bytes.toVector))
 
-    assert(enumerator.run(length) === F.pure(105397))
+    assert(enumerator.into(length) === F.pure(105397))
   }
 
   "readBytesFromStream" should "enumerate bytes from a stream" in {
@@ -46,7 +46,7 @@ abstract class FileModuleSuite[F[_]: Monad] extends ModuleSuite[F] {
       case (_, stream) => readBytesFromStream(stream)
     }.flatMap(bytes => enumVector(bytes.toVector))
 
-    assert(enumerator.run(length) === F.pure(105397))
+    assert(enumerator.into(length) === F.pure(105397))
   }
 
   "readZipStreams" should "enumerate files in a zip archive" in {
@@ -56,14 +56,14 @@ abstract class FileModuleSuite[F[_]: Monad] extends ModuleSuite[F] {
       case (_, stream) => readLinesFromStream(stream)
     }
 
-    assert(enumerator.run(length) === F.pure(1981))
+    assert(enumerator.into(length) === F.pure(1981))
   }
 
   it should "work with an iteratee that stops early" in {
     val zip = new File(getClass.getResource("/io/iteratee/examples/pg/11231/11231.zip").toURI)
     val enumerator = readZipStreams(zip).map(_._1.getName)
 
-    assert(enumerator.run(head) === F.pure(Some("11231.txt")))
+    assert(enumerator.into(head) === F.pure(Some("11231.txt")))
   }
 
   "listFiles" should "enumerate files in a directory" in {
@@ -93,7 +93,7 @@ abstract class FileModuleSuite[F[_]: Monad] extends ModuleSuite[F] {
     val tmp = File.createTempFile("it-writeLines", ".txt")
     tmp.deleteOnExit()
 
-    assert(enumList(lines).run(writeLines(tmp)) === F.pure(()))
+    assert(enumList(lines).into(writeLines(tmp)) === F.pure(()))
     assert(readLines(tmp).toVector === F.pure(lines.toVector))
   }
 
@@ -102,7 +102,7 @@ abstract class FileModuleSuite[F[_]: Monad] extends ModuleSuite[F] {
     tmp.deleteOnExit()
     val stream = new FileOutputStream(tmp)
 
-    assert(enumList(lines).run(writeLinesToStream(stream)) === F.pure(()))
+    assert(enumList(lines).into(writeLinesToStream(stream)) === F.pure(()))
     assert(readLines(tmp).toVector === F.pure(lines.toVector))
   }
 
@@ -110,7 +110,7 @@ abstract class FileModuleSuite[F[_]: Monad] extends ModuleSuite[F] {
     val tmp = File.createTempFile("it-writeBytes", ".txt")
     tmp.deleteOnExit()
 
-    assert(enumList(bytes).run(writeBytes(tmp)) === F.pure(()))
+    assert(enumList(bytes).into(writeBytes(tmp)) === F.pure(()))
     assert(readBytes(tmp).toVector.map(_.flatMap(_.toVector)) === F.pure(bytes.toVector.flatten))
   }
 
@@ -118,7 +118,7 @@ abstract class FileModuleSuite[F[_]: Monad] extends ModuleSuite[F] {
     val tmp = File.createTempFile("it-writeBytesToStream", ".txt")
     tmp.deleteOnExit()
 
-    assert(enumList(bytes).run(writeBytes(tmp)) === F.pure(()))
+    assert(enumList(bytes).into(writeBytes(tmp)) === F.pure(()))
     assert(readBytes(tmp).toVector.map(_.flatMap(_.toVector)) === F.pure(bytes.toVector.flatten))
   }
 }

--- a/tests/shared/src/main/scala/io/iteratee/tests/ArbitraryEnumerators.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/ArbitraryEnumerators.scala
@@ -7,7 +7,7 @@ trait ArbitraryEnumerators[F[_]] {
   this: ModuleSuite[F] with Module[F] with EnumeratorModule[F] with IterateeModule[F] =>
 
   case class EnumeratorAndValues[A](enumerator: Enumerator[F, A], values: Vector[A]) {
-    def resultWithLeftovers[Z](iteratee: Iteratee[F, A, Z]): F[(Z, Vector[A])] = enumerator.run(
+    def resultWithLeftovers[Z](iteratee: Iteratee[F, A, Z]): F[(Z, Vector[A])] = enumerator.into(
       iteratee.flatMap(result => consume[A].map(leftovers => (result, leftovers))(F))(F)
     )(F)
   }

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
@@ -57,16 +57,16 @@ abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
   }
 
   "repeat" should "repeat a value" in forAll { (i: Int, count: Short) =>
-    assert(repeat(i).run(takeI(count.toInt)) === F.pure(Vector.fill(count.toInt)(i)))
+    assert(repeat(i).into(takeI(count.toInt)) === F.pure(Vector.fill(count.toInt)(i)))
   }
 
   "iterate" should "enumerate values by applying a function iteratively" in forAll { (n: Int, count: Short) =>
-    assert(iterate(n)(_ + 1).run(takeI(count.toInt)) === F.pure(Vector.iterate(n, count.toInt)(_ + 1)))
+    assert(iterate(n)(_ + 1).into(takeI(count.toInt)) === F.pure(Vector.iterate(n, count.toInt)(_ + 1)))
   }
 
   "iterateM" should "enumerate values by applying a pure function iteratively" in {
     forAll { (n: Int, count: Short) =>
-      assert(iterateM(n)(i => F.pure(i + 1)).run(takeI(count.toInt)) === F.pure(Vector.iterate(n, count.toInt)(_ + 1)))
+      assert(iterateM(n)(i => F.pure(i + 1)).into(takeI(count.toInt)) === F.pure(Vector.iterate(n, count.toInt)(_ + 1)))
     }
   }
 
@@ -82,7 +82,7 @@ abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
     val taken = n - math.abs(fewer.toInt)
     val enumerator = iterateUntil(0)(i => if (i == count) None else Some(i + 1))
 
-    assert(enumerator.run(takeI(taken)) === F.pure((0 to count).toVector.take(taken)))
+    assert(enumerator.into(takeI(taken)) === F.pure((0 to count).toVector.take(taken)))
   }
 
   "iterateUntilM" should "apply a pure function until it returns an empty result" in forAll { (n: Short) =>
@@ -97,7 +97,7 @@ abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
     val taken = n - math.abs(fewer.toInt)
     val enumerator = iterateUntilM(0)(i => F.pure(if (i == count) None else Some(i + 1)))
 
-    assert(enumerator.run(takeI(taken)) === F.pure((0 to count).toVector.take(taken)))
+    assert(enumerator.into(takeI(taken)) === F.pure((0 to count).toVector.take(taken)))
   }
 
   "toVector" should "collect all the values in the stream" in forAll { (eav: EnumeratorAndValues[Int]) =>
@@ -109,7 +109,7 @@ abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
   }
 
   it should "work with a done iteratee" in {
-    assert(enumOne(0).append(enumOne(2).prepend(1)).run(head) === F.pure((Some(0))))
+    assert(enumOne(0).append(enumOne(2).prepend(1)).into(head) === F.pure((Some(0))))
   }
 
   "bindM" should "bind through Option" in forAll { (eav: EnumeratorAndValues[Int]) =>
@@ -162,21 +162,21 @@ abstract class StackSafeEnumeratorSuite[F[_]: Monad] extends EnumeratorSuite[F] 
     this: Module[F] with EnumerateeModule[F] with EnumeratorModule[F] with IterateeModule[F] =>
 
   "StackUnsafe.repeat" should "be consistent with repeat" in forAll { (i: Int, count: Short) =>
-    val expected = repeat(i).run(takeI(count.toInt))
+    val expected = repeat(i).into(takeI(count.toInt))
 
-    assert(Enumerator.StackUnsafe.repeat[F, Int](i).run(takeI(count.toInt)) === expected)
+    assert(Enumerator.StackUnsafe.repeat[F, Int](i).into(takeI(count.toInt)) === expected)
   }
 
   "StackUnsafe.iterate" should "be consistent with iterate" in forAll { (n: Int, count: Short) =>
-    val expected = iterate(n)(_ + 1).run(takeI(count.toInt))
+    val expected = iterate(n)(_ + 1).into(takeI(count.toInt))
 
-    assert(Enumerator.StackUnsafe.iterate[F, Int](n)(_ + 1).run(takeI(count.toInt)) === expected)
+    assert(Enumerator.StackUnsafe.iterate[F, Int](n)(_ + 1).into(takeI(count.toInt)) === expected)
   }
 
   "StackUnsafe.iterateM" should "be consistent with iterateM" in forAll { (n: Int, count: Short) =>
-    val expected = iterateM(n)(i => F.pure(i + 1)).run(takeI(count.toInt))
+    val expected = iterateM(n)(i => F.pure(i + 1)).into(takeI(count.toInt))
 
-    assert(Enumerator.StackUnsafe.iterateM[F, Int](n)(i => F.pure(i + 1)).run(takeI(count.toInt)) === expected)
+    assert(Enumerator.StackUnsafe.iterateM[F, Int](n)(i => F.pure(i + 1)).into(takeI(count.toInt)) === expected)
   }
 
   "StackUnsafe.iterateUntil" should "be consistent with iterateUntil" in forAll { (n: Short) =>

--- a/tests/shared/src/main/scala/io/iteratee/tests/EqInstances.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EqInstances.scala
@@ -19,10 +19,10 @@ trait EqInstances {
     val e3 = Enumerator.enumVector[F, A](Arbitrary.arbitrary[Vector[A]].sample.get)
 
     Eq.instance { (i, j) =>
-      eq.eqv(e0.run(i), e0.run(j)) &&
-      eq.eqv(e1.run(i), e1.run(j)) &&
-      eq.eqv(e2.run(i), e2.run(j)) &&
-      eq.eqv(e3.run(i), e3.run(j))
+      eq.eqv(e0.into(i), e0.into(j)) &&
+      eq.eqv(e1.into(i), e1.into(j)) &&
+      eq.eqv(e2.into(i), e2.into(j)) &&
+      eq.eqv(e3.into(i), e3.into(j))
     }
   }
 
@@ -35,10 +35,10 @@ trait EqInstances {
     val e3 = Enumerator.enumVector[F, A](Arbitrary.arbitrary[Vector[A]].sample.get)
 
     Eq.instance { (i, j) =>
-      eq.eqv(e0.mapE(i).toVector, e0.mapE(j).toVector) &&
-      eq.eqv(e1.mapE(i).toVector, e1.mapE(j).toVector) &&
-      eq.eqv(e2.mapE(i).toVector, e2.mapE(j).toVector) &&
-      eq.eqv(e3.mapE(i).toVector, e3.mapE(j).toVector)
+      eq.eqv(e0.through(i).toVector, e0.through(j).toVector) &&
+      eq.eqv(e1.through(i).toVector, e1.through(j).toVector) &&
+      eq.eqv(e2.through(i).toVector, e2.through(j).toVector) &&
+      eq.eqv(e3.through(i).toVector, e3.through(j).toVector)
     }
   }
 }

--- a/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
@@ -88,7 +88,7 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
   )
 
   "cont" should "work recursively in an iteratee returning a list" in forAll { (eav: EnumeratorAndValues[Int]) =>
-    assert(eav.enumerator.run(myDrain(Nil)) === F.map(eav.enumerator.toVector)(_.toList))
+    assert(eav.enumerator.into(myDrain(Nil)) === F.map(eav.enumerator.toVector)(_.toList))
   }
 
   it should "work with fold with one value" in forAll { (es: List[Int]) =>
@@ -195,7 +195,7 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
       r <- consume
     } yield r
 
-    assert(enumVector(Vector(1, 2, 3)).run(iteratee) === F.pure(Vector.empty))
+    assert(enumVector(Vector(1, 2, 3)).into(iteratee) === F.pure(Vector.empty))
   }
 
   "fold" should "collapse the stream into a value" in forAll { (eav: EnumeratorAndValues[Int]) =>
@@ -255,13 +255,13 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
 
   "flatMapM" should "apply an effectful function" in {
     forAll { (eav: EnumeratorAndValues[Int], iteratee: Iteratee[F, Int, Int]) =>
-      assert(eav.enumerator.run(iteratee.flatMapM(F.pure)) === eav.enumerator.run(iteratee))
+      assert(eav.enumerator.into(iteratee.flatMapM(F.pure)) === eav.enumerator.into(iteratee))
     }
   }
 
   "contramap" should "apply a function on incoming values" in {
     forAll { (eav: EnumeratorAndValues[Int], iteratee: Iteratee[F, Int, Int]) =>
-      assert(eav.enumerator.run(iteratee.contramap(_ + 1)) === eav.enumerator.map(_ + 1).run(iteratee))
+      assert(eav.enumerator.into(iteratee.contramap(_ + 1)) === eav.enumerator.map(_ + 1).into(iteratee))
     }
   }
 
@@ -305,8 +305,8 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     val iteratee2 = takeI[Int](2).zip(takeI(3)).zip(consume)
     val result = ((es.take(2), es.take(3)), es)
 
-    assert(enumerator.run(iteratee1) === F.pure(result))
-    assert(enumerator.run(iteratee2) === F.pure(result))
+    assert(enumerator.into(iteratee1) === F.pure(result))
+    assert(enumerator.into(iteratee2) === F.pure(result))
   }
 
   "foldMap" should "fold a stream while transforming it" in forAll { (eav: EnumeratorAndValues[Int]) =>

--- a/tests/shared/src/test/scala/io/iteratee/EvalTests.scala
+++ b/tests/shared/src/test/scala/io/iteratee/EvalTests.scala
@@ -7,9 +7,9 @@ class EvalEnumerateeTests extends EnumerateeSuite[Eval] with EvalSuite {
   "take" should "work with more than Int.MaxValue values" in forAll { (n: Int) =>
     val items = Vector.fill(1000000)(())
     val totalSize: Long = Int.MaxValue.toLong + math.max(1, n).toLong
-    val enumerator = repeat(()).flatMap(_ => enumVector(items)).mapE(take(totalSize))
+    val enumerator = repeat(()).flatMap(_ => enumVector(items)).through(take(totalSize))
 
-    assert(enumerator.run(length) === F.pure(totalSize))
+    assert(enumerator.into(length) === F.pure(totalSize))
   }
 }
 

--- a/tests/shared/src/test/scala/io/iteratee/XorTests.scala
+++ b/tests/shared/src/test/scala/io/iteratee/XorTests.scala
@@ -10,9 +10,9 @@ class XorEnumerateeTests extends EnumerateeSuite[({ type L[x] = XorT[Eval, Throw
   "take" should "work with more than Int.MaxValue values" in forAll { (n: Int) =>
     val items = Vector.fill(1000000)(())
     val totalSize: Long = Int.MaxValue.toLong + math.max(1, n).toLong
-    val enumerator = repeat(()).flatMap(_ => enumVector(items)).mapE(take(totalSize))
+    val enumerator = repeat(()).flatMap(_ => enumVector(items)).through(take(totalSize))
 
-    assert(enumerator.run(length) === F.pure(totalSize))
+    assert(enumerator.into(length) === F.pure(totalSize))
   }
 }
 
@@ -47,7 +47,7 @@ class XorEnumeratorTests extends StackSafeEnumeratorSuite[({ type L[x] = XorT[Ev
     val n = math.max(0, eav.values.size - 2)
 
     assert(counter == 0)
-    assert(enumerator.run(takeI(n)) === F.pure(eav.values.take(n)))
+    assert(enumerator.into(takeI(n)) === F.pure(eav.values.take(n)))
     assert(counter === 1)
   }
 
@@ -90,7 +90,7 @@ class XorIterateeTests extends IterateeErrorSuite[({ type L[x] = XorT[Eval, Thro
         }
       )
 
-      assert(eav.enumerator.run(xorIteratee) === F.pure(pureEnumerator.run(iteratee)))
+      assert(eav.enumerator.into(xorIteratee) === F.pure(pureEnumerator.into(iteratee)))
     }
   }
 


### PR DESCRIPTION
I'd like to rename `mapE` and `run` on `Enumerator`.

`mapE` is an inheritance from Scalaz, and I just don't like it much—if you already know what it means it's clear that it's about mapping an enumeratee, but something like `through` (which I've chosen here) or `transform` makes it clearer that you're attaching a pipe to a source.

`run` is borrowed from Play (and kind of from scalaz-stream), and I've found it potentially confusing when explaining the library to people, since for most interesting contexts it doesn't actually run anything. I've replaced it with `into` here (I think I'd prefer `to` if that weren't widely used in other libraries to indicate a conversion).

If either `mapE` or `run` were standard terms here, I'd be much more reluctant to replace them, but they're not really, and I think we can do a little better.
