### PR TITLE
Simplify zip's return type and constraint

### DIFF
--- a/core/src/main/scala/io/iteratee/Iteratee.scala
+++ b/core/src/main/scala/io/iteratee/Iteratee.scala
@@ -84,8 +84,8 @@ sealed class Iteratee[F[_], E, A] private[iteratee] (final val state: F[Step[F, 
    * Zip this [[Iteratee]] with another to create an iteratee that returns a
    * pair of their results.
    */
-  final def zip[B](other: Iteratee[F, E, B])(implicit F: Monad[F]): Iteratee[F, E, (A, B)] =
-    Iteratee.iteratee(F.flatten(F.map2(self.state, other.state)(_.zip(_))))
+  final def zip[B](other: Iteratee[F, E, B])(implicit F: Applicative[F]): Iteratee[F, E, (A, B)] =
+    Iteratee.iteratee(F.map2(self.state, other.state)(_.zip(_)))
 
   /**
    * If this [[Iteratee]] has failed, use the provided function to recover.

--- a/core/src/main/scala/io/iteratee/internal/Step.scala
+++ b/core/src/main/scala/io/iteratee/internal/Step.scala
@@ -58,7 +58,7 @@ abstract class Step[F[_], E, A] extends Serializable {
   /**
    * Zip this [[Step]] with another.
    */
-  def zip[B](other: Step[F, E, B])(implicit M: Monad[F]): F[Step[F, E, (A, B)]]
+  def zip[B](other: Step[F, E, B]): Step[F, E, (A, B)]
 }
 
 


### PR DESCRIPTION
I just noticed that the `Monad` constraint and `F` in the return type don't seem to be necessary. The `Monad` constraint was inherited from Scalaz, but there the `zip` for iteratees is [broken](https://github.com/scalaz/scalaz/issues/1068), anyway.