### PR TITLE
Update Monix and remove monix-cats

### DIFF
--- a/benchmark/src/main/scala/io/iteratee/benchmark/Benchmark.scala
+++ b/benchmark/src/main/scala/io/iteratee/benchmark/Benchmark.scala
@@ -5,9 +5,9 @@ import cats.instances.int._
 import com.twitter.util.{ Await => AwaitT, Duration => DurationT }
 import io.catbird.util.Rerunnable
 import io.{ iteratee => i }
+import io.iteratee.monix.MonixInstances
 import io.iteratee.scalaz.ScalazInstances
 import java.util.concurrent.TimeUnit
-import monix.cats._
 import monix.eval.{ Task => TaskM }
 import org.openjdk.jmh.annotations._
 import play.api.libs.{ iteratee => p }
@@ -21,7 +21,7 @@ import scalaz.std.anyVal.intInstance
 import scalaz.std.vector._
 import scalaz.stream.Process
 
-class IterateeBenchmark extends ScalazInstances
+class IterateeBenchmark extends MonixInstances with ScalazInstances
 
 class InMemoryExampleData extends IterateeBenchmark {
   private[this] val count = 10000

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ val scalaVersions = Seq("2.10.6", "2.11.8")
 
 lazy val catsVersion = "0.7.2"
 lazy val disciplineVersion = "0.4"
-lazy val monixVersion = "2.0.4"
+lazy val monixVersion = "2.0.5"
 lazy val scalaCheckVersion = "1.12.5"
 lazy val scalaTestVersion = "3.0.0-M9"
 
@@ -181,8 +181,7 @@ lazy val monixBase = crossProject.in(file("monix"))
   .settings(Defaults.itSettings: _*)
   .settings(
     libraryDependencies ++= Seq(
-      "io.monix" %%% "monix-eval" % monixVersion,
-      "io.monix" %%% "monix-cats" % monixVersion
+      "io.monix" %%% "monix-eval" % monixVersion
     )
   )
   .jsSettings(commonJsSettings: _*)

--- a/monix/js/src/main/scala/io/iteratee/monix/TaskModule.scala
+++ b/monix/js/src/main/scala/io/iteratee/monix/TaskModule.scala
@@ -1,14 +1,17 @@
 package io.iteratee.monix
 
 import cats.MonadError
-import io.iteratee.{EnumerateeModule, EnumeratorErrorModule, IterateeErrorModule, Module}
-import monix.cats.monixToCatsMonadError
+import io.iteratee.{ EnumerateeModule, EnumeratorErrorModule, IterateeErrorModule, Module }
 import monix.eval.Task
 
 trait TaskModule extends Module[Task]
-  with EnumerateeModule[Task]
-  with EnumeratorErrorModule[Task, Throwable] with IterateeErrorModule[Task, Throwable] {
+    with EnumerateeModule[Task]
+    with EnumeratorErrorModule[Task, Throwable] with IterateeErrorModule[Task, Throwable] {
   final type M[f[_]] = MonadError[f, Throwable]
+}
 
-  final protected val F: MonadError[Task, Throwable] = monixToCatsMonadError[Task, Throwable]
+final object TaskModule {
+  def instance(implicit taskMonadError: MonadError[Task, Throwable]): TaskModule = new TaskModule {
+    final protected val F: MonadError[Task, Throwable] = taskMonadError
+  }
 }

--- a/monix/jvm/src/it/scala/io/iteratee/monix/TaskFileModuleTests.scala
+++ b/monix/jvm/src/it/scala/io/iteratee/monix/TaskFileModuleTests.scala
@@ -2,14 +2,14 @@ package io.iteratee.monix
 
 import cats.Eq
 import cats.data.Xor
+import io.iteratee.monix.task._
 import io.iteratee.tests.files.FileModuleSuite
-import monix.cats._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class TaskFileModuleTests extends FileModuleSuite[Task] with TaskModule {
+class TaskFileModuleTests extends FileModuleSuite[Task] with DefaultTaskModule {
   def monadName: String = "Task"
 
   implicit def eqF[A: Eq]: Eq[Task[A]] = Eq.by { task =>

--- a/monix/jvm/src/main/scala/io/iteratee/monix/TaskModule.scala
+++ b/monix/jvm/src/main/scala/io/iteratee/monix/TaskModule.scala
@@ -3,15 +3,19 @@ package io.iteratee.monix
 import cats.MonadError
 import io.iteratee.{ EnumerateeModule, EnumeratorErrorModule, IterateeErrorModule, Module }
 import io.iteratee.files.SuspendableFileModule
-import monix.cats.monixToCatsMonadError
 import monix.eval.Task
 
 trait TaskModule extends Module[Task]
-  with EnumerateeModule[Task]
-  with EnumeratorErrorModule[Task, Throwable] with IterateeErrorModule[Task, Throwable]
-  with SuspendableFileModule[Task] {
+    with EnumerateeModule[Task]
+    with EnumeratorErrorModule[Task, Throwable] with IterateeErrorModule[Task, Throwable]
+    with SuspendableFileModule[Task] {
   final type M[f[_]] = MonadError[f, Throwable]
 
-  final protected val F: MonadError[Task, Throwable] = monixToCatsMonadError[Task, Throwable]
   final protected def captureEffect[A](a: => A): Task[A] = Task.delay(a)
+}
+
+final object TaskModule {
+  def instance(implicit taskMonadError: MonadError[Task, Throwable]): TaskModule = new TaskModule {
+    final protected val F: MonadError[Task, Throwable] = taskMonadError
+  }
 }

--- a/monix/jvm/src/test/scala/io/iteratee/monix/TaskTests.scala
+++ b/monix/jvm/src/test/scala/io/iteratee/monix/TaskTests.scala
@@ -2,14 +2,14 @@ package io.iteratee.monix
 
 import cats.Eq
 import cats.data.Xor
+import io.iteratee.monix.task._
 import io.iteratee.tests.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, ModuleSuite, eqThrowable }
-import monix.cats._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-trait TaskSuite extends ModuleSuite[Task] with TaskModule {
+trait TaskSuite extends ModuleSuite[Task] with DefaultTaskModule {
   def monadName: String = "Task"
 
   implicit def eqF[A: Eq]: Eq[Task[A]] = Eq.by { task =>

--- a/monix/shared/src/main/scala/io/iteratee/monix/DefaultTaskModule.scala
+++ b/monix/shared/src/main/scala/io/iteratee/monix/DefaultTaskModule.scala
@@ -1,0 +1,8 @@
+package io.iteratee.monix
+
+import cats.MonadError
+import monix.eval.Task
+
+trait DefaultTaskModule extends TaskModule with MonixInstances {
+  final protected val F: MonadError[Task, Throwable] = monixTaskMonadError
+}

--- a/monix/shared/src/main/scala/io/iteratee/monix/MonixInstances.scala
+++ b/monix/shared/src/main/scala/io/iteratee/monix/MonixInstances.scala
@@ -1,0 +1,24 @@
+package io.iteratee.monix
+
+import cats.MonadError
+import monix.eval.Task
+
+/**
+ * Type class instances for Monix types.
+ *
+ * Note that in most cases you should use the instances provided by monix-cats.
+ * This trait is provided for convenience when monix-cats is not available.
+ */
+trait MonixInstances {
+  implicit final val monixTaskMonadError: MonadError[Task, Throwable] = new MonadError[Task, Throwable] {
+    final def pure[A](x: A): Task[A] = Task.now(x)
+    final def flatMap[A, B](fa: Task[A])(f: A => Task[B]): Task[B] = fa.flatMap(f)
+    override final def map[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
+    final def raiseError[A](e: Throwable): Task[A] = Task.raiseError(e)
+    final def handleErrorWith[A](fa: Task[A])(f: Throwable => Task[A]): Task[A] = fa.onErrorHandleWith(f)
+    final def tailRecM[A, B](a: A)(f: A => Task[Either[A, B]]): Task[B] = f(a).flatMap {
+      case Right(b) => pure(b)
+      case Left(nextA) => tailRecM(nextA)(f)
+    }
+  }
+}

--- a/monix/shared/src/main/scala/io/iteratee/monix/package.scala
+++ b/monix/shared/src/main/scala/io/iteratee/monix/package.scala
@@ -1,5 +1,14 @@
 package io.iteratee
 
+/**
+ * Module and instances for Monix.
+ *
+ * There are two ways to use this package. If your project has a monix-cats
+ * dependency, you can import the type class instances it provides and then
+ * instantiate a Monix module with `val module = TaskModule.instance`. If you do
+ * not have a monix-cats dependency, you can use the `io.iteratee.monix.task`
+ * module directly.
+ */
 package object monix {
-  final object task extends TaskModule
+  final object task extends DefaultTaskModule
 }


### PR DESCRIPTION
This PR removes the monix-cats dependency from the iteratee-monix module in order to simplify the process of publishing new releases after a Cats update. Now users can decide whether they want to depend on monix-cats and use its instances (if the versions line up and that's an option), or to use the `MonadError[Task]` provided here.

In the immediate future this means that we can publish the 0.7.0 release as soon as Cats 0.8.0 is out, without waiting for a version of monix-cats for 0.8.0.