### PR TITLE
Let chunks be strings

### DIFF
--- a/core/src/main/scala/io/iteratee/Enumerator.scala
+++ b/core/src/main/scala/io/iteratee/Enumerator.scala
@@ -2,7 +2,7 @@ package io.iteratee
 
 import cats.{ Applicative, FlatMap, Monad, MonadError, Semigroup, Eval }
 import io.iteratee.internal.Step
-import scala.Predef.=:=
+import scala.Predef.{ $conforms, =:= }
 import scala.util.{ Left, Right }
 
 abstract class Enumerator[F[_], E] extends Serializable { self =>
@@ -117,6 +117,15 @@ final object Enumerator extends EnumeratorInstances {
   final def enumOne[F[_]: Applicative, E](e: E): Enumerator[F, E] = new Enumerator[F, E] {
     final def apply[A](s: Step[F, E, A]): F[Step[F, E, A]] = s.feedEl(e)
   }
+
+  /**
+   * An enumerator that produces the characters of a string (potentially without
+   * representing it as a sequence).
+   */
+  final def enumString[F[_]](input: String)(implicit F: Applicative[F]): Enumerator[F, Char] =
+    new Enumerator[F, Char] {
+      final def apply[A](s: Step[F, Char, A]): F[Step[F, Char, A]] = s.feed(input)
+    }
 
   private[this] abstract class ChunkedIteratorEnumerator[F[_], E](implicit F: Monad[F]) extends Enumerator[F, E] {
     def chunks: Iterator[Vector[E]]

--- a/core/src/main/scala/io/iteratee/EnumeratorModule.scala
+++ b/core/src/main/scala/io/iteratee/EnumeratorModule.scala
@@ -46,6 +46,14 @@ trait EnumeratorModule[F[_]] { this: Module[F] =>
   final def enumOne[E](e: E): Enumerator[F, E] = Enumerator.enumOne(e)(F)
 
   /**
+   * An enumerator that produces the characters of a string (potentially without
+   * representing it as a sequence).
+   *
+   * @group Enumerators
+   */
+  final def enumString(input: String): Enumerator[F, Char] = Enumerator.enumString(input)(F)
+
+  /**
    * An enumerator that produces values from a stream.
    *
    * @group Enumerators

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
@@ -28,6 +28,10 @@ abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
     assert(enumOne(i).toVector === F.pure(Vector(i)))
   }
 
+  "enumString" should "produce the same values as enumList" in forAll { (input: String) =>
+    assert(enumString(input).toVector === enumList(input.toList).toVector)
+  }
+
   "enumStream" should "enumerate values from a stream" in forAll { (xs: Stream[Int]) =>
     assert(enumStream(xs).toVector === F.pure(xs.toVector))
   }


### PR DESCRIPTION
I'm working on a new iteratee-parsing module with iteratee-powered parser combinators, and I really want to be able to parse strings as streams of characters without representing chunks as sequences of characters. This PR is a first step in that direction.

There's no measurable impact on performance (at least in the benchmarks I've looked at so far), since the `IsSeqLike` instances get instantiated once for each type involved, and in the case where the chunks _are_ sequences, the conversion is just identity.