### PR TITLE
Update benchmark versions and remove Play

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
     fi;
   - if [[ "$TRAVIS_SCALA_VERSION" == 2.12.* ]];
     then
-      sbt ++$TRAVIS_SCALA_VERSION twitter/test twitter/it:test;
+      sbt ++$TRAVIS_SCALA_VERSION twitter/test twitter/it:test benchmark/test;
     fi;
 
   # See http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html

--- a/benchmark/src/test/scala/io/iteratee/benchmark/InMemoryBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/iteratee/benchmark/InMemoryBenchmarkSpec.scala
@@ -30,15 +30,11 @@ class InMemoryBenchmarkSpec extends FlatSpec {
     assert(benchmark.sumInts5Z === sum)
   }
 
-  it should "correctly calculate the sum using play-iteratee" in {
-    assert(benchmark.sumInts6P === sum)
+  it should "correctly calculate the sum using fs2" in {
+    assert(benchmark.sumInts6F === sum)
   }
 
   it should "correctly calculate the sum using the collections library" in {
     assert(benchmark.sumInts7C === sum)
-  }
-
-  it should "correctly calculate the sum using fs2" in {
-    assert(benchmark.sumInts8F === sum)
   }
 }

--- a/benchmark/src/test/scala/io/iteratee/benchmark/StreamingBenchmarkSpec.scala
+++ b/benchmark/src/test/scala/io/iteratee/benchmark/StreamingBenchmarkSpec.scala
@@ -31,15 +31,11 @@ class StreamingBenchmarkSpec extends FlatSpec {
     assert(benchmark.takeLongs5Z === taken)
   }
 
-  it should "correctly gather elements using play-iteratee" in {
-    assert(benchmark.takeLongs6P === taken)
+  it should "correctly gather elements using fs2" in {
+    assert(benchmark.takeLongs6F === taken)
   }
 
   it should "correctly gather elements using the collections library" in {
     assert(benchmark.takeLongs7C === taken)
-  }
-
-  it should "correctly gather elements using fs2" in {
-    assert(benchmark.takeLongs8F === taken)
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -208,18 +208,17 @@ lazy val monixJS = monixBase.js
 lazy val benchmark = project
   .configs(IntegrationTest)
   .settings(
-    crossScalaVersions := scalaVersions.tail.init,
+    crossScalaVersions := scalaVersions.tail,
     moduleName := "iteratee-benchmark"
   )
   .settings(allSettings ++ Defaults.itSettings)
   .settings(noPublishSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "co.fs2" %% "fs2-core" % "0.9.1",
-      "com.typesafe.play" %% "play-iteratees" % "2.6.0",
+      "co.fs2" %% "fs2-core" % "0.9.2",
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
-      "org.scalaz" %% "scalaz-iteratee" % "7.2.6",
-      "org.scalaz.stream" %% "scalaz-stream" % "0.8.4a",
+      "org.scalaz" %% "scalaz-iteratee" % "7.2.7",
+      "org.scalaz.stream" %% "scalaz-stream" % "0.8.6a",
       "org.typelevel" %% "cats-free" % catsVersion
     )
   )


### PR DESCRIPTION
The Play results weren't very interesting, and I wanted an easy way to compare performance on Scala 2.12.0 (which play-iteratee isn't published for).