### PR TITLE
Fix NPE in future files module

### DIFF
--- a/files/src/main/scala/io/iteratee/files/package.scala
+++ b/files/src/main/scala/io/iteratee/files/package.scala
@@ -8,7 +8,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Try
 
 package object files {
-  def future(implicit ec0: ExecutionContext): FileModule[Future] = new FutureFileModule {
+  def future(implicit ec0: ExecutionContext): FutureModule with FileModule[Future] = new FutureFileModule {
     final protected def ec: ExecutionContext = ec0
   }
 }

--- a/files/src/main/scala/io/iteratee/files/package.scala
+++ b/files/src/main/scala/io/iteratee/files/package.scala
@@ -9,7 +9,7 @@ import scala.util.Try
 
 package object files {
   def future(implicit ec0: ExecutionContext): FileModule[Future] = new FutureFileModule {
-    final protected val ec: ExecutionContext = ec0
+    final protected def ec: ExecutionContext = ec0
   }
 }
 


### PR DESCRIPTION
Fixes #168. See #169 for an explanation of why this PR doesn't include new tests that fail before the fix.

I've also added `FutureModule` to the `future` signature to bring it into line with the other files modules.