### PR TITLE
fix odd case in Iteratee.foreach

### DIFF
--- a/core/src/main/scala/io/iteratee/internal/Step.scala
+++ b/core/src/main/scala/io/iteratee/internal/Step.scala
@@ -108,8 +108,7 @@ final object Step { self =>
         case Done(otherValue, otherRemaining) => F.pure(Done(otherValue, otherRemaining ++ remaining))
         case step =>
           val c = remaining.lengthCompare(1)
-
-          if (c < 0) f(value) else if (c == 0) step.feedEl(remaining.head) else step.feedNonEmpty(remaining)
+          if (c < 0) F.pure(step) else if (c == 0) step.feedEl(remaining.head) else step.feedNonEmpty(remaining)
       }
 
     final def zip[B](other: Step[F, E, B]): Step[F, E, (A, B)] = other match {

--- a/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
@@ -237,6 +237,17 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     assert(eav.resultWithLeftovers(iteratee) === F.pure(((), Vector.empty)) && total === eav.values.sum)
   }
 
+  "foreach" should "perform an operation on all values in a grouped stream" in {
+    forAll { (eav: EnumeratorAndValues[Int]) =>
+      val eavg = EnumeratorAndValues(eav.enumerator.grouped(3), eav.values.grouped(3).toVector)
+
+      var total = 0
+      val iteratee = foreach[Vector[Int]](is => total += is.sum)
+
+      assert(eavg.resultWithLeftovers(iteratee) === F.pure(((), Vector.empty)) && total === eavg.values.flatten.sum)
+    }
+  }
+
   "foreachM" should "perform an effectful operation on all values in a stream" in {
     forAll { (eav: EnumeratorAndValues[Int]) =>
       var total = 0


### PR DESCRIPTION
For your consideration. The test I wrote is maybe a little overkill: no real need to create an extra `EnumeratorAndValues`. I can try to simplify that if you like.

The added test fails without the fix, and passes with it.