### PR TITLE
Rename and deprecated identity in iteratee module

### DIFF
--- a/core/src/main/scala/io/iteratee/IterateeModule.scala
+++ b/core/src/main/scala/io/iteratee/IterateeModule.scala
@@ -43,12 +43,19 @@ trait IterateeModule[F[_]] { self: Module[F] =>
    */
   final def liftToIteratee[E]: LiftToIterateePartiallyApplied[E] = new LiftToIterateePartiallyApplied[E]
 
+  /**
+   * An iteratee that reads nothing from a stream.
+   *
+   * @group Iteratees
+   */
+  final def identityIteratee[E]: Iteratee[F, E, Unit] = Iteratee.identity(F)
 
   /**
    * An iteratee that reads nothing from a stream.
    *
    * @group Iteratees
    */
+  @deprecated("Use identityIteratee", "0.10.0")
   final def identity[E]: Iteratee[F, E, Unit] = Iteratee.identity(F)
 
   /**

--- a/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
@@ -138,16 +138,16 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     assert(liftToIteratee(F.pure(i)).run === F.pure(i))
   }
 
-  "identity" should "consume no input" in forAll { (eav: EnumeratorAndValues[Int], it: Iteratee[F, Int, Int]) =>
-    assert(eav.resultWithLeftovers(identity) === F.pure(((), eav.values)))
-    assert(eav.resultWithLeftovers(identity.flatMap(_ => it)) === eav.resultWithLeftovers(it))
+  "identityIteratee" should "consume no input" in forAll { (eav: EnumeratorAndValues[Int], it: Iteratee[F, Int, Int]) =>
+    assert(eav.resultWithLeftovers(identityIteratee) === F.pure(((), eav.values)))
+    assert(eav.resultWithLeftovers(identityIteratee.flatMap(_ => it)) === eav.resultWithLeftovers(it))
   }
 
   "consume" should "consume the entire stream" in forAll { (eav: EnumeratorAndValues[Int]) =>
     val result = eav.resultWithLeftovers(consume)
 
     assert(result === F.pure((eav.values, Vector.empty)))
-    assert(result === eav.resultWithLeftovers(identity.flatMap(_ => consume)))
+    assert(result === eav.resultWithLeftovers(identityIteratee.flatMap(_ => consume)))
   }
 
   "consumeIn" should "consume the entire stream" in forAll { (eav: EnumeratorAndValues[Int]) =>


### PR DESCRIPTION
It's annoying to import the contents of a module and have `identity` clash with `Predef.identity` (I use `-Yno-predef` enough that I'm just now coming across this). This deprecation doesn't fix the annoyance, but it does set us up to fix it in the next release.

I also considered `idIteratee` and `iterateeIdentity` as names, but went with `identityIteratee` for the sake of consistency with `failIteratee` and to avoid confusion with `cats.Id`.