### PR TITLE
Add enumeratees that inject values

### DIFF
--- a/core/src/main/scala/io/iteratee/Enumeratee.scala
+++ b/core/src/main/scala/io/iteratee/Enumeratee.scala
@@ -453,6 +453,20 @@ final object Enumeratee extends EnumerateeInstances {
     final def apply[A](step: Step[F, E, A]): F[Step[F, E, Step[F, E, A]]] = F.pure(doneOrLoop(true)(step))
   }
 
+  /**
+   * Inject a value into a stream.
+   */
+  def injectValue[F[_], E](e: E)(implicit F: Monad[F]): Enumeratee[F, E, E] = new Enumeratee[F, E, E] {
+    def apply[A](step: Step[F, E, A]): F[Step[F, E, Step[F, E, A]]] = F.flatMap(step.feedEl(e))(identity[F, E].apply)
+  }
+
+  /**
+   * Inject zero or more values into a stream.
+   */
+  def injectValues[F[_], E](es: Seq[E])(implicit F: Monad[F]): Enumeratee[F, E, E] = new Enumeratee[F, E, E] {
+    def apply[A](step: Step[F, E, A]): F[Step[F, E, Step[F, E, A]]] = F.flatMap(step.feed(es))(identity[F, E].apply)
+  }
+
   abstract class PureLoop[F[_], O, I](implicit F: Applicative[F]) extends Enumeratee[F, O, I] {
     protected def loop[A](step: Step[F, I, A]): Step[F, O, Step[F, I, A]]
 

--- a/core/src/main/scala/io/iteratee/EnumerateeModule.scala
+++ b/core/src/main/scala/io/iteratee/EnumerateeModule.scala
@@ -149,4 +149,14 @@ trait EnumerateeModule[F[_]] { this: Module[F] =>
    * @group Enumeratees
    */
   final def intersperse[E](delim: E): Enumeratee[F, E, E] = Enumeratee.intersperse(delim)(F)
+
+  /**
+   * Inject a value into a stream.
+   */
+  final def injectValue[E](e: E): Enumeratee[F, E, E] = Enumeratee.injectValue(e)(F)
+
+  /**
+   * Inject zero or more values into a stream.
+   */
+  final def injectValues[E](es: Seq[E]): Enumeratee[F, E, E] = Enumeratee.injectValues(es)(F)
 }

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
@@ -272,4 +272,20 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
       assert(eav.resultWithLeftovers(consume[Int].through(intersperse(delim))) === F.pure((expected, Vector.empty)))
     }
   }
+
+  "injectValue" should "add a value at the head of the stream" in {
+    forAll { (eav: EnumeratorAndValues[Int], e: Int) =>
+      val expected = e +: eav.values
+
+      assert(eav.resultWithLeftovers(consume[Int].through(injectValue(e))) === F.pure((expected, Vector.empty)))
+    }
+  }
+
+  "injectValues" should "add values at the head of the stream" in {
+    forAll { (eav: EnumeratorAndValues[Int], es: Seq[Int]) =>
+      val expected = es.toVector ++ eav.values
+
+      assert(eav.resultWithLeftovers(consume[Int].through(injectValues(es))) === F.pure((expected, Vector.empty)))
+    }
+  }
 }


### PR DESCRIPTION
In an application I'm currently working on I'm needing to enumerate a bunch of values and write a high-level summary to one file and a more direct representation to another file, and having an enumeratee that supports injecting values (header lines, etc.) makes this more convenient.