### PR TITLE
Make sequenceI stack-safe

### DIFF
--- a/core/src/main/scala/io/iteratee/IterateeInstances.scala
+++ b/core/src/main/scala/io/iteratee/IterateeInstances.scala
@@ -23,8 +23,8 @@ private class IterateeMonad[F[_], E](implicit F: Monad[F]) extends Monad[Iterate
   override final def map[A, B](fa: Iteratee[F, E, A])(f: A => B): Iteratee[F, E, B] = fa.map(f)
   final def flatMap[A, B](fa: Iteratee[F, E, A])(f: A => Iteratee[F, E, B]): Iteratee[F, E, B] = fa.flatMap(f)
 
-  final def tailRecM[A, B](a: A)(f: A => Iteratee[F, E, Either[A, B]]): Iteratee[F, E, B] = Iteratee.iteratee(
-    F.map(f(a).state)(Step.tailRecM(a => f(a).state))
+  final def tailRecM[A, B](a: A)(f: A => Iteratee[F, E, Either[A, B]]): Iteratee[F, E, B] = Iteratee.fromStep(
+    Step.tailRecM[F, E, A, B](a)(f(_).state)
   )
 }
 

--- a/core/src/main/scala/io/iteratee/internal/Step.scala
+++ b/core/src/main/scala/io/iteratee/internal/Step.scala
@@ -524,10 +524,12 @@ final object Step { self =>
           } else {
             F.flatMap(f(a))(s => F.map(s.feedNonEmpty(remaining))(Left(_)))
           }
-        case cont => F.map(cont.run) {
-          case Right(b) => Right(Step.done(b))
-          case Left(a) => Right(new TailRecMCont(a)(f))
-        }
+        case cont => F.map(
+          cont.bind[B] {
+            case Right(b) => F.pure(Step.done(b))
+            case Left(a) => F.pure(new TailRecMCont(a)(f))
+          }
+        )(Right(_))
       }
 
     final def feedEl(e: E): F[Step[F, E, B]] =

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
@@ -186,6 +186,10 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     }
   }
 
+  it should "be stack safe even for large chunks" in {
+    assert(enumVector((0 until 10000).toVector).sequenceI(takeI(2)).into(length) === F.pure(5000))
+  }
+
   "uniq" should "drop duplicate values" in forAll { (xs: Vector[Int]) =>
     val sorted = xs.sorted
 

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
@@ -187,7 +187,11 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
   }
 
   it should "be stack safe even for large chunks" in {
-    assert(enumVector((0 until 10000).toVector).sequenceI(takeI(2)).into(length) === F.pure(5000))
+    val groupedSize = 3
+    val xs = (0 until 10000).toVector
+    val expected = xs.grouped(groupedSize).size.toLong
+
+    assert(enumVector(xs).sequenceI(takeI(groupedSize)).into(length) === F.pure(expected))
   }
 
   "uniq" should "drop duplicate values" in forAll { (xs: Vector[Int]) =>


### PR DESCRIPTION
Somehow #180 turned up a (pre-existing) bug involving the stack-safety of `sequenceI`, which is currently causing tests to fail occasionally. The issue is that `sequenceI` flat-maps recursively, which can cause problems on large chunks for monads that don't provide their own stack-safe recursive binding. For example:

```scala
import cats.Monad
import io.iteratee.{ Enumerator, Iteratee }

def checkStackSafety[F[_]: Monad]: F[Long] =
  Enumerator.enumVector[F, Int]((0 to 10000).toVector).grouped(3).into(Iteratee.length)
``` 

And then:

```scala
scala> import cats.instances.option._
import cats.instances.option._

scala> checkStackSafety[Option]
java.lang.StackOverflowError
  at scala.collection.immutable.Vector.take(Vector.scala:160)
  at scala.collection.immutable.Vector.splitAt(Vector.scala:215)
  at io.iteratee.internal.Step$TakeCont.feedNonEmptyPure(Step.scala:441)
  ...
```

But this for example is just fine:

```scala
import io.iteratee.monix.task._
import monix.eval.Task
import monix.execution.Scheduler.Implicits.global

checkStackSafety[Task].foreach(println)
```

The `Option` case would also be okay if we'd defined `checkStackSafety` like this:

```scala
def checkStackSafety[F[_]: Monad]: F[Long] =
  Enumerator.iterate[F, Int](0)(_ + 1).take(10000).grouped(3).into(Iteratee.length)
```

This PR addresses the issue by writing `sequenceI` in terms of `tailRecM`.

There are two problems we need to address before this gets merged. First, a couple of tests are currently failing for iteratee-monix with this error:

```
[info]   IllegalArgumentException was thrown during property evaluation.
[info]     Message: requirement failed: size=0 and step=0, but both must be positive
```

I'm not sure what this means, and googling doesn't help much.

The other (easier) issue is that I want to add some tests to verify the fix.

As soon as these things are done I'll publish 0.10.0.