### PR TITLE
Add enumIterable and minor changes to enumStream

### DIFF
--- a/core/src/main/scala/io/iteratee/EnumeratorModule.scala
+++ b/core/src/main/scala/io/iteratee/EnumeratorModule.scala
@@ -10,6 +10,8 @@ import cats.MonadError
  * @groupprio Helpers 4
  */
 trait EnumeratorModule[F[_]] { this: Module[F] =>
+  private[this] final def defaultChunkSize: Int = 1024
+
   /**
    * Lift an effectful value into an enumerator.
    *
@@ -53,11 +55,20 @@ trait EnumeratorModule[F[_]] { this: Module[F] =>
   final def enumOne[E](e: E): Enumerator[F, E] = Enumerator.enumOne(e)(F)
 
   /**
+   * An enumerator that produces values from an iterable collection.
+   *
+   * @group Enumerators
+   */
+  final def enumIterable[E](es: Iterable[E], chunkSize: Int = defaultChunkSize): Enumerator[F, E] =
+    Enumerator.enumIterable(es, chunkSize)(F)
+
+  /**
    * An enumerator that produces values from a stream.
    *
    * @group Enumerators
    */
-  final def enumStream[E](es: Stream[E]): Enumerator[F, E] = Enumerator.enumStream(es)(F)
+  final def enumStream[E](es: Stream[E], chunkSize: Int = defaultChunkSize): Enumerator[F, E] =
+    Enumerator.enumStream(es, chunkSize)(F)
 
   /**
    * An enumerator that produces values from a list.

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
@@ -32,8 +32,12 @@ abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
     assert(enumOne(i).toVector === F.pure(Vector(i)))
   }
 
-  "enumStream" should "enumerate values from a stream" in forAll { (xs: Stream[Int]) =>
-    assert(enumStream(xs).toVector === F.pure(xs.toVector))
+  "enumIterable" should "enumerate values from an iterable" in forAll { (xs: Iterable[Int], chunkSize: Int) =>
+    assert(enumIterable(xs, chunkSize).toVector === F.pure(xs.toVector))
+  }
+
+  "enumStream" should "enumerate values from a stream" in forAll { (xs: Stream[Int], chunkSize: Int) =>
+    assert(enumStream(xs, chunkSize).toVector === F.pure(xs.toVector))
   }
 
   "enumList" should "enumerate values from a list" in forAll { (xs: List[Int]) =>


### PR DESCRIPTION
The new `enumIterable` is pretty self-explanatory. There are two main other changes:

`Enumerator.enumStream` no longer blows up when the chunk size is zero or smaller, and it's now possible to pass in a chunk size to the module version of `enumStream`.