### PR TITLE
Less leftovers

### DIFF
--- a/core/src/main/scala/io/iteratee/Iteratee.scala
+++ b/core/src/main/scala/io/iteratee/Iteratee.scala
@@ -145,15 +145,6 @@ final object Iteratee extends IterateeInstances {
   final def done[F[_]: Applicative, E, A](value: A): Iteratee[F, E, A] = fromStep(Step.done(value))
 
   /**
-   * Create a new completed [[Iteratee]] with the given result and leftover
-   * input.
-   *
-   * @group Constructors
-   */
-  final def doneWithLeftovers[F[_]: Applicative, E, A](value: A, remaining: List[E]): Iteratee[F, E, A] =
-    fromStep(Step.doneWithLeftovers(value, remaining))
-
-  /**
    * Create an [[Iteratee]] from a [[io.iteratee.internal.Step]] in a context.
    *
    * @group Utilities

--- a/core/src/main/scala/io/iteratee/IterateeModule.scala
+++ b/core/src/main/scala/io/iteratee/IterateeModule.scala
@@ -21,13 +21,11 @@ trait IterateeModule[F[_]] { self: Module[F] =>
     Iteratee.cont(ifInput, ifEnd)(F)
 
   /**
-   * Create a new completed [[Iteratee]] with the given result and leftover
-   * input.
+   * Create a new completed [[Iteratee]] with the given result.
    *
    * @group Constructors
    */
-  final def done[E, A](value: A, remaining: List[E] = Nil): Iteratee[F, E, A] =
-    Iteratee.doneWithLeftovers(value, remaining)(F)
+  final def done[E, A](value: A): Iteratee[F, E, A] = Iteratee.done(value)(F)
 
   /**
    * @group Helpers


### PR DESCRIPTION
This PR does three major things. The first thing is a change to the behavior you see when you bind an iteratee that's done with leftovers into another iteratee that's done with leftovers. The previous behavior made the binding associative in these cases, but it's not associative in similar cases (e.g. binding a continuation iteratee into an iteratee that's done with leftovers), anyway, and complicating the implementation to paper over one case seems kind of silly in retrospect.

To make this more concrete, here are two examples of broken associativity with this PR:

```scala
import cats.instances.option._, cats.syntax.all._
import io.iteratee.Iteratee, io.iteratee.internal.Step, io.iteratee.modules.option._

val done1 = Iteratee.fromStep(Step.doneWithLeftovers((), List(1, 2, 3)))
val done2 = Iteratee.fromStep(Step.doneWithLeftovers((), List(4, 5)))
```

And then:

```scala
scala> ((head[Int] >> done1) >> consume).run
res0: Option[Vector[Int]] = Some(Vector())

scala> (head[Int] >> (done1 >> consume)).run
res1: Option[Vector[Int]] = Some(Vector(1, 2, 3))

scala> ((done1 >> done2) >> consume).run
res2: Option[Vector[Int]] = Some(Vector(1, 2, 3))

scala> (done1 >> (done2 >> consume)).run
res3: Option[Vector[Int]] = Some(Vector(4, 5, 1, 2, 3))
```

In previous version the first pair gives the same (non-associative) results, while the second pair does match (both are `Vector(4, 5, 1, 2, 3)`, which is kind of counterintuitive, anyway). The solution is don't do this. Don't manually construct iteratees with leftovers and bind into them. The other two changes are designed to encourage you not to do that.

(For what it's worth, the new version matches the behavior of Haskell iteratee libraries like [enumerator](http://hackage.haskell.org/package/enumerator).)

The second change is that `Iteratee.doneWithLeftovers` is entirely gone. If you're currently using this method, you'll need to switch to `Step.doneWithLeftovers` and `Iteratee.fromStep`. In general, though, you shouldn't be constructing iteratees with leftovers directly, and having a method like this just sitting there is an invitation to create unlawful iteratees.

The third change is that the `remainder` field on `Step.Done` is now private to the `internal` package. As far as I know there's no good reason ever to look at this in user code—we need it for binding (both the `flatMap` and `tailRecM` flavors), and for zipping, but that's it.
