### PR TITLE
Add remainderWithResult

### DIFF
--- a/core/src/main/scala/io/iteratee/Enumeratee.scala
+++ b/core/src/main/scala/io/iteratee/Enumeratee.scala
@@ -313,6 +313,27 @@ final object Enumeratee extends EnumerateeInstances {
     }
 
   /**
+   * Run an iteratee and then use the provided function to combine the result
+   * with the remaining elements.
+   */
+  final def remainderWithResult[F[_], O, R, I](iteratee: Iteratee[F, O, R])(f: (R, O) => I)(implicit
+    F: Monad[F]
+  ): Enumeratee[F, O, I] =
+    new Enumeratee[F, O, I] {
+      private[this] class TransformingCont[A](r: R)(step: Step[F, I, A]) extends StepCont[F, O, I, A](step) {
+        private[this] def advance(next: Step[F, I, A]): Step[F, O, Step[F, I, A]] =
+          if (next.isDone) Step.done(next) else new TransformingCont(r)(next)
+
+        final def feedEl(e: O): F[Step[F, O, Step[F, I, A]]] = F.map(step.feedEl(f(r, e)))(advance)
+        final protected def feedNonEmpty(chunk: Seq[O]): F[Step[F, O, Step[F, I, A]]] =
+          F.map(step.feed(chunk.map(f(r, _))))(advance)
+      }
+
+      final def apply[A](step: Step[F, I, A]): F[Step[F, O, Step[F, I, A]]] =
+        F.flatMap(iteratee.state)(_.bind(r => F.pure(new TransformingCont(r)(step))))
+    }
+
+  /**
    * Collapse consecutive duplicates.
    *
    * @note Assumes that the stream is sorted.

--- a/core/src/main/scala/io/iteratee/EnumerateeModule.scala
+++ b/core/src/main/scala/io/iteratee/EnumerateeModule.scala
@@ -107,6 +107,15 @@ trait EnumerateeModule[F[_]] { this: Module[F] =>
   final def sequenceI[O, I](iteratee: Iteratee[F, O, I]): Enumeratee[F, O, I] = Enumeratee.sequenceI(iteratee)(F)
 
   /**
+   * Run an iteratee and then use the provided function to combine the result
+   * with the remaining elements.
+   *
+   * @group Enumeratees
+   */
+  final def remainderWithResult[O, R, I](iteratee: Iteratee[F, O, R])(f: (R, O) => I): Enumeratee[F, O, I] =
+    Enumeratee.remainderWithResult(iteratee)(f)(F)
+
+  /**
    * Collapse consecutive duplicates.
    *
    * @note Assumes that the stream is sorted.

--- a/core/src/main/scala/io/iteratee/EnumerateeModule.scala
+++ b/core/src/main/scala/io/iteratee/EnumerateeModule.scala
@@ -116,6 +116,15 @@ trait EnumerateeModule[F[_]] { this: Module[F] =>
     Enumeratee.remainderWithResult(iteratee)(f)(F)
 
   /**
+   * Run an iteratee and then use the provided effectful function to combine the
+   * result with the remaining elements.
+   *
+   * @group Enumeratees
+   */
+  final def remainderWithResultM[O, R, I](iteratee: Iteratee[F, O, R])(f: (R, O) => F[I]): Enumeratee[F, O, I] =
+    Enumeratee.remainderWithResultM(iteratee)(f)(F)
+
+  /**
    * Collapse consecutive duplicates.
    *
    * @note Assumes that the stream is sorted.

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
@@ -218,6 +218,25 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     }
   }
 
+  "remainderWithResultM" should "return an empty result for iteratees that consume all input" in {
+    forAll { (eav: EnumeratorAndValues[Int]) =>
+      val enumeratee = remainderWithResultM(consume[Int])((r, i) => F.pure(r))
+
+      assert(eav.enumerator.through(enumeratee).toVector === F.pure(Vector.empty))
+    }
+  }
+
+  it should "add the first n values to subsequent values" in {
+    forAll { (eav: EnumeratorAndValues[Int], n: Byte) =>
+      val enumeratee = remainderWithResultM(takeI[Int](n.toInt))((r, i) => F.pure(i + r.sum))
+
+      val (firstN, rest) = eav.values.splitAt(n.toInt)
+      val expected = rest.map(_ + firstN.sum)
+
+      assert(eav.enumerator.through(enumeratee).toVector === F.pure(expected))
+    }
+  }
+
   "uniq" should "drop duplicate values" in forAll { (xs: Vector[Int]) =>
     val sorted = xs.sorted
 


### PR DESCRIPTION
This enumeratee is useful when you want to capture something like header-parsing logic in an enumerator instead of an enumeratee. One quick example—suppose you have a file like this:

```
3
cat
bat
dog
foo
```

…where the first line is a header that indicates how long each of the lines must be.

You could parse it like this:

```scala
import cats.instances.option._, io.iteratee.modules.option._
import scala.util.Try

val goodLines = enumerate("3", "cat", "bat", "dog", "foo")
val badLines = enumerate("3", "cat", "bat", "dog", "bird", "foo")

def validateLine(header: Int)(line: String): Option[String] =
  if (line.size == header) Some(line) else None

val parseHeader = head[String].flatMapM {
  case Some(line) => Try(line.toInt).toOption
  case None => None
}

val parseLines = for {
  header <- parseHeader
  rest <- consume[String].through(flatMapM(validateLine(header)))
} yield rest
```

And then:

```scala
scala> goodLines.into(parseLines)
res0: Option[Vector[String]] = Some(Vector(cat, bat, dog, foo))

scala> badLines.into(parseLines)
res1: Option[Vector[String]] = None
```

But in some cases you want the line parsing logic in an enumerator, which you can now express like this:

```scala
val words = remainderWithResultM(parseHeader)(Function.uncurried(validateLine _))
```

And then:

```scala
scala> goodLines.through(words).toVector
res2: Option[Vector[String]] = Some(Vector(cat, bat, dog, foo))

scala> badLines.through(words).toVector
res3: Option[Vector[String]] = None
```

The iteratee version is probably nicer in most cases, but I've wanted the enumerator version often enough to add it, I think.