### PR TITLE
Add enumeratees for observing chunks and rechunking

### DIFF
--- a/core/src/main/scala/io/iteratee/Enumeratee.scala
+++ b/core/src/main/scala/io/iteratee/Enumeratee.scala
@@ -593,13 +593,4 @@ final object Enumeratee extends EnumerateeInstances {
 
     final def apply[A](step: Step[F, I, A]): F[Step[F, O, Step[F, I, A]]] = F.pure(doneOrLoop(step))
   }
-
-  private[this] abstract class EffectfulLoop[F[_], O, I](implicit F: Applicative[F]) extends Enumeratee[F, O, I] {
-    protected def loop[A](step: Step[F, I, A]): F[Step[F, O, Step[F, I, A]]]
-
-    protected final def doneOrLoop[A](step: Step[F, I, A]): F[Step[F, O, Step[F, I, A]]] =
-      if (step.isDone) F.pure(Step.done(step)) else loop(step)
-
-    final def apply[A](step: Step[F, I, A]): F[Step[F, O, Step[F, I, A]]] = doneOrLoop(step)
-  }
 }

--- a/core/src/main/scala/io/iteratee/Enumeratee.scala
+++ b/core/src/main/scala/io/iteratee/Enumeratee.scala
@@ -3,6 +3,7 @@ package io.iteratee
 import cats.{ Applicative, Eq, FlatMap, Monad }
 import cats.instances.list.catsStdInstancesForList
 import io.iteratee.internal.Step
+import scala.collection.mutable.Builder
 
 abstract class Enumeratee[F[_], O, I] extends Serializable { self =>
   def apply[A](step: Step[F, I, A]): F[Step[F, O, Step[F, I, A]]]
@@ -487,6 +488,85 @@ final object Enumeratee extends EnumerateeInstances {
   def injectValues[F[_], E](es: Seq[E])(implicit F: Monad[F]): Enumeratee[F, E, E] = new Enumeratee[F, E, E] {
     def apply[A](step: Step[F, E, A]): F[Step[F, E, Step[F, E, A]]] = F.flatMap(step.feed(es))(identity[F, E].apply)
   }
+
+  /**
+   * Observe the chunks in a stream.
+   *
+   * @note Typically you should never rely on the underlying chunking of a
+   * stream, but in some cases it can be useful.
+   */
+  final def chunks[F[_], E](implicit F: Applicative[F]): Enumeratee[F, E, Vector[E]] =
+    new PureLoop[F, E, Vector[E]] {
+      protected def loop[A](step: Step[F, Vector[E], A]): Step[F, E, Step[F, Vector[E], A]] =
+        new StepCont[F, E, Vector[E], A](step) {
+          final def feedEl(e: E): F[Step[F, E, Step[F, Vector[E], A]]] =
+            F.map(step.feedEl(Vector(e)))(doneOrLoop)
+          final protected def feedNonEmpty(chunk: Seq[E]): F[Step[F, E, Step[F, Vector[E], A]]] =
+            F.map(step.feedEl(chunk.toVector))(doneOrLoop)
+        }
+    }
+
+  private[this] final class Rechunk1[F[_], E](implicit F: Monad[F]) extends PureLoop[F, E, E] {
+    protected def loop[A](step: Step[F, E, A]): Step[F, E, Step[F, E, A]] = new StepCont[F, E, E, A](step) {
+      final def feedEl(e: E): F[Step[F, E, Step[F, E, A]]] = F.map(step.feedEl(e))(doneOrLoop)
+      final protected def feedNonEmpty(chunk: Seq[E]): F[Step[F, E, Step[F, E, A]]] = F.map(
+        chunk.tail.foldLeft(step.feedEl(chunk.head)) {
+          case (next, e) => F.flatMap(next)(_.feedEl(e))
+        }
+      )(doneOrLoop)
+    }
+  }
+
+  private[this] final class RechunkN[F[_], E](size: Int)(implicit F: Monad[F]) extends Enumeratee[F, E, E] {
+    private[this] def freshBuilder(): Builder[E, Vector[E]] = {
+      val builder = Vector.newBuilder[E]
+      builder.sizeHint(size)
+      builder
+    }
+
+    private[this] def loop[A](current: Int, acc: Builder[E, Vector[E]])(
+      step: Step[F, E, A]
+    ): Step[F, E, Step[F, E, A]] = new Step.Cont[F, E, Step[F, E, A]] {
+      final def run: F[Step[F, E, A]] = step.feed(acc.result())
+
+      final def feedEl(e: E): F[Step[F, E, Step[F, E, A]]] = if (current + 1 == size) {
+        F.flatMap(step.feed((acc += e).result()))(doneOrLoop(0, freshBuilder()))
+      } else F.pure(loop(current + 1, acc += e)(step))
+
+      final protected def feedNonEmpty(chunk: Seq[E]): F[Step[F, E, Step[F, E, A]]] = {
+        val c = chunk.lengthCompare(size - current)
+
+        if (c < 0) F.pure(loop(current + chunk.size, acc ++= chunk)(step)) else if (c == 0) {
+          F.flatMap(step.feed((acc ++= chunk).result()))(doneOrLoop(0, freshBuilder()))
+        } else {
+          val newChunks = (acc ++= chunk).result().grouped(size)
+
+          val (nextStep, lastChunk) = newChunks.foldLeft((F.pure(step), Vector.empty[E])) {
+            case ((ns, lc), es) =>
+              if (es.size == size) (F.flatMap(ns)(_.feed(es)), Vector.empty) else (ns, es)
+          }
+
+          F.flatMap(nextStep)(doneOrLoop(lastChunk.size, freshBuilder() ++= lastChunk))
+        }
+      }
+    }
+
+    private[this] final def doneOrLoop[A](current: Int, acc: Builder[E, Vector[E]])(
+      step: Step[F, E, A]
+    ): F[Step[F, E, Step[F, E, A]]] = if (step.isDone) {
+      if (current == 0) F.pure(Step.done(step)) else {
+        F.map(step.feed(acc.result()))(Step.done[F, E, Step[F, E, A]](_))
+      }
+    } else F.pure(loop(current, acc)(step))
+
+    final def apply[A](step: Step[F, E, A]): F[Step[F, E, Step[F, E, A]]] = doneOrLoop(0, freshBuilder())(step)
+  }
+
+  /**
+   * Rechunk elements in the stream into chunks of the provided size.
+   */
+  final def rechunk[F[_], E](size: Int)(implicit F: Monad[F]): Enumeratee[F, E, E] =
+    if (size <= 1) new Rechunk1[F, E] else new RechunkN[F, E](size)
 
   private[this] abstract class StepCont[F[_], O, I, A](step: Step[F, I, A])(implicit
     F: Applicative[F]

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumerateeSuite.scala
@@ -348,4 +348,15 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
 
     assert(eav.enumerator.through(enumeratee).toVector === F.pure(expected))
   }
+
+  it should "correctly handle some corner cases" in {
+    val enumerator1 = enumIndexedSeq(0 to 20).through(Enumeratee.rechunk(5))
+    val enumerator2 = iterate(0)(_ + 1).through(Enumeratee.rechunk(5))
+    val enumerator3 = enumVector((0 until 5).toVector)
+    val enumerator4 = enumerator3.append(enumerator3).through(Enumeratee.rechunk(5))
+
+    assert(enumerator1.into(takeI(6)) === F.pure((0 until 6).toVector))
+    assert(enumerator2.into(takeI(6)) === F.pure((0 until 6).toVector))
+    assert(enumerator4.toVector === F.pure(((0 until 5) ++ (0 until 5)).toVector))
+  }
 }

--- a/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/EnumeratorSuite.scala
@@ -1,6 +1,6 @@
 package io.iteratee.tests
 
-import cats.{ Eq, Monad }
+import cats.{ Eq, Eval, Monad }
 import cats.kernel.laws.GroupLaws
 import cats.laws.discipline.{ CartesianTests, MonadTests }
 import io.iteratee.{ EnumerateeModule, Enumerator, EnumeratorModule, IterateeModule, Module }
@@ -18,6 +18,20 @@ abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
 
   "liftToEnumerator" should "lift a value in a context into an enumerator" in forAll { (i: Int) =>
     assert(liftToEnumerator(F.pure(i)).toVector === F.pure(Vector(i)))
+  }
+
+  "liftMEval" should "lift a value in a context into an enumerator" in forAll { (i: Int) =>
+    var counter = 0
+    val eval = Eval.later {
+      counter += i
+      F.pure(i)
+    }
+
+    val enumerator = Enumerator.liftMEval(eval)
+
+    assert(counter === 0)
+    assert(enumerator.toVector === F.pure(Vector(i)))
+    assert(counter === i)
   }
 
   "enumerate" should "enumerate varargs values" in forAll { (xs: List[Int]) =>

--- a/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/IterateeSuite.scala
@@ -147,6 +147,34 @@ abstract class BaseIterateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     assert(liftToIteratee(F.pure(i)).run === F.pure(i))
   }
 
+  it should "lift a value in a context when run on an enumerator" in forAll { (eav: EnumeratorAndValues[Int], i: Int) =>
+    assert(eav.enumerator.into(liftToIteratee(F.pure(i))) === F.pure(i))
+  }
+
+  "liftMEval" should "lift a value in a context into an iteratee" in forAll { (i: Int) =>
+    var counter = 0
+    val eval = Eval.later {
+      counter += i
+      F.pure(i)
+    }
+
+    assert(counter === 0)
+    assert(Iteratee.liftMEval(eval).run === F.pure(i))
+    assert(counter === i)
+  }
+
+  it should "lift a value in a context when run on an enumerator" in forAll { (eav: EnumeratorAndValues[Int], i: Int) =>
+    var counter = 0
+    val eval = Eval.later {
+      counter += i
+      F.pure(i)
+    }
+
+    assert(counter === 0)
+    assert(eav.enumerator.into(Iteratee.liftMEval(eval)) === F.pure(i))
+    assert(counter === i)
+  }
+
   "identityIteratee" should "consume no input" in forAll { (eav: EnumeratorAndValues[Int], it: Iteratee[F, Int, Int]) =>
     assert(eav.resultWithLeftovers(identityIteratee) === F.pure(((), eav.values)))
     assert(eav.resultWithLeftovers(identityIteratee.flatMap(_ => it)) === eav.resultWithLeftovers(it))


### PR DESCRIPTION
Note that these methods are intentionally not included in `EnumerateeModule`, since they should be used rarely.