### PR TITLE
Update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val fs2Version = "0.9.7"
 lazy val fs2CatsVersion = "0.4.0"
 
 lazy val scalaCheckVersion = "1.13.5"
-lazy val scalaTestVersion = "3.0.3"
+lazy val scalaTestVersion = "3.0.4"
 
 lazy val previousIterateeVersion = "0.13.0"
 
@@ -168,7 +168,7 @@ lazy val twitter = project
   )
   .settings(allSettings ++ Defaults.itSettings)
   .settings(
-    libraryDependencies += "io.catbird" %% "catbird-util" % "0.17.0"
+    libraryDependencies += "io.catbird" %% "catbird-util" % "0.18.0"
   ).dependsOn(core, files, tests % "test,it")
 
 lazy val scalaz = project


### PR DESCRIPTION
Finch now uses iteratee but their finagle versions (provided here by catbird) don't line up. It's probably that `7.0.0` and `7.1.0` line up but I've been burnt so many times by finagles random binary incompatibilities that I'm motivated on this.