### PR TITLE
New iteratee-testing module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -153,16 +153,8 @@ lazy val testsBase = crossProject.in(file("tests"))
     parallelExecution in Test := true,
     testForkedParallel in Test := true,
     parallelExecution in IntegrationTest := true,
-    testForkedParallel in IntegrationTest := true
-  )
-  .settings(
-    coverageExcludedPackages := "io\\.iteratee\\.tests\\..*",
-    testOptions in Test ++= (
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 10)) => Seq(Tests.Argument("-l", "io.iteratee.tests.NoScala210Test"))
-        case _ => Nil
-      }
-    )
+    testForkedParallel in IntegrationTest := true,
+    coverageExcludedPackages := "io\\.iteratee\\.tests\\..*"
   )
   .jvmSettings(fork := false)
   .jsSettings(commonJsSettings: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,8 @@ lazy val testingBase = crossProject.in(file("testing"))
       "org.scalatest" %%% "scalatest" % scalaTestVersion,
       "org.typelevel" %%% "cats-laws" % catsVersion,
       "org.typelevel" %%% "discipline" % disciplineVersion
-    )
+    ),
+    coverageExcludedPackages := "io\\.iteratee\\.testing\\..*"
   )
   .jsSettings(commonJsSettings: _*)
   .jvmConfigure(_.copy(id = "testing").dependsOn(files))

--- a/fs2/jvm/src/it/scala/io/iteratee/fs2/TaskFileModuleTests.scala
+++ b/fs2/jvm/src/it/scala/io/iteratee/fs2/TaskFileModuleTests.scala
@@ -3,7 +3,7 @@ package io.iteratee.fs2
 import cats.Eq
 import fs2.Task
 import io.iteratee.fs2.task._
-import io.iteratee.tests.files.FileModuleSuite
+import io.iteratee.testing.files.FileModuleSuite
 
 class TaskFileModuleTests extends FileModuleSuite[Task] with TaskModule {
   def monadName: String = "Task"

--- a/fs2/shared/src/test/scala/io/iteratee/fs2/TaskTests.scala
+++ b/fs2/shared/src/test/scala/io/iteratee/fs2/TaskTests.scala
@@ -4,7 +4,8 @@ import cats.Eq
 import cats.laws.discipline.arbitrary.catsLawsCogenForThrowable
 import fs2.Task
 import fs2.interop.cats._
-import io.iteratee.tests.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, ModuleSuite, eqThrowable }
+import io.iteratee.testing.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, ModuleSuite }
+import io.iteratee.testing.EqInstances.eqThrowable
 
 trait TaskSuite extends ModuleSuite[Task] with TaskModule {
   def monadName: String = "Task"

--- a/monix/jvm/src/it/scala/io/iteratee/monix/TaskFileModuleTests.scala
+++ b/monix/jvm/src/it/scala/io/iteratee/monix/TaskFileModuleTests.scala
@@ -2,7 +2,7 @@ package io.iteratee.monix
 
 import cats.Eq
 import io.iteratee.monix.task._
-import io.iteratee.tests.files.FileModuleSuite
+import io.iteratee.testing.files.FileModuleSuite
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import scala.concurrent.Await

--- a/monix/jvm/src/test/scala/io/iteratee/monix/TaskTests.scala
+++ b/monix/jvm/src/test/scala/io/iteratee/monix/TaskTests.scala
@@ -3,7 +3,8 @@ package io.iteratee.monix
 import cats.Eq
 import cats.laws.discipline.arbitrary.catsLawsCogenForThrowable
 import io.iteratee.monix.task._
-import io.iteratee.tests.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, ModuleSuite, eqThrowable }
+import io.iteratee.testing.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, ModuleSuite }
+import io.iteratee.testing.EqInstances.eqThrowable
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import scala.concurrent.Await

--- a/scalaz/src/it/scala/io/iteratee/scalaz/TaskFileModuleTests.scala
+++ b/scalaz/src/it/scala/io/iteratee/scalaz/TaskFileModuleTests.scala
@@ -1,7 +1,7 @@
 package io.iteratee.scalaz
 
 import cats.Eq
-import io.iteratee.tests.files.FileModuleSuite
+import io.iteratee.testing.files.FileModuleSuite
 import scalaz.concurrent.Task
 
 class TaskFileModuleTests extends FileModuleSuite[Task] with TaskModule {

--- a/scalaz/src/test/scala/io/iteratee/scalaz/TaskTests.scala
+++ b/scalaz/src/test/scala/io/iteratee/scalaz/TaskTests.scala
@@ -2,7 +2,8 @@ package io.iteratee.scalaz
 
 import cats.Eq
 import cats.laws.discipline.arbitrary.catsLawsCogenForThrowable
-import io.iteratee.tests.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, ModuleSuite, eqThrowable }
+import io.iteratee.testing.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, ModuleSuite }
+import io.iteratee.testing.EqInstances.eqThrowable
 import scalaz.concurrent.Task
 
 trait TaskSuite extends ModuleSuite[Task] with TaskModule {

--- a/testing/jvm/src/main/scala/io/iteratee/testing/files/FileModuleSuite.scala
+++ b/testing/jvm/src/main/scala/io/iteratee/testing/files/FileModuleSuite.scala
@@ -1,11 +1,12 @@
-package io.iteratee.tests.files
+package io.iteratee.testing.files
 
 import cats.Monad
 import io.iteratee.{ EnumeratorModule, IterateeModule, Module }
 import io.iteratee.files.FileModule
-import io.iteratee.tests.ModuleSuite
+import io.iteratee.testing.ModuleSuite
 import java.io.{ File, FileInputStream, FileOutputStream }
 import org.scalacheck.Gen
+import scala.Predef._
 
 abstract class FileModuleSuite[F[_]: Monad] extends ModuleSuite[F] {
   this: Module[F] with EnumeratorModule[F] with IterateeModule[F] with FileModule[F] =>

--- a/testing/shared/src/main/scala/io/iteratee/testing/ArbitraryEnumerators.scala
+++ b/testing/shared/src/main/scala/io/iteratee/testing/ArbitraryEnumerators.scala
@@ -1,4 +1,4 @@
-package io.iteratee.tests
+package io.iteratee.testing
 
 import io.iteratee.{ Enumerator, EnumeratorModule, Iteratee, IterateeModule, Module }
 import org.scalacheck.{ Arbitrary, Gen }

--- a/testing/shared/src/main/scala/io/iteratee/testing/ArbitraryInstances.scala
+++ b/testing/shared/src/main/scala/io/iteratee/testing/ArbitraryInstances.scala
@@ -1,9 +1,10 @@
-package io.iteratee.tests
+package io.iteratee.testing
 
 import cats.Monad
 import cats.instances.int._
 import io.iteratee.{ Iteratee, Enumeratee, Enumerator }
 import org.scalacheck.{ Arbitrary, Gen }
+import scala.Predef._
 
 trait ArbitraryInstances {
   implicit def arbitraryEnumerator[F[_]: Monad, A](implicit

--- a/testing/shared/src/main/scala/io/iteratee/testing/BaseSuite.scala
+++ b/testing/shared/src/main/scala/io/iteratee/testing/BaseSuite.scala
@@ -1,0 +1,28 @@
+package io.iteratee.testing
+
+import cats.instances.AllInstances
+import cats.kernel.Eq
+import cats.syntax.AllSyntax
+import io.iteratee.{ EnumeratorModule, IterateeModule, Module }
+import org.scalatest.FlatSpec
+import org.scalatest.prop.{ Checkers, GeneratorDrivenPropertyChecks }
+import org.typelevel.discipline.Laws
+
+class BaseSuite extends FlatSpec with GeneratorDrivenPropertyChecks
+  with AllInstances with AllSyntax
+  with ArbitraryInstances with EqInstances {
+  override def convertToEqualizer[T](left: T): Equalizer[T] =
+    sys.error("Intentionally ambiguous implicit for Equalizer")
+
+  def checkLaws(name: String, ruleSet: Laws#RuleSet): Unit = ruleSet.all.properties.zipWithIndex.foreach {
+    case ((id, prop), 0) => name should s"obey $id" in Checkers.check(prop)
+    case ((id, prop), _) => it should s"obey $id" in Checkers.check(prop)
+  }
+}
+
+abstract class ModuleSuite[F[_]] extends BaseSuite with ArbitraryEnumerators[F] {
+  this: Module[F] with EnumeratorModule[F] with IterateeModule[F] =>
+
+  def monadName: String
+  implicit def eqF[A: Eq]: Eq[F[A]]
+}

--- a/testing/shared/src/main/scala/io/iteratee/testing/EnumerateeSuite.scala
+++ b/testing/shared/src/main/scala/io/iteratee/testing/EnumerateeSuite.scala
@@ -151,11 +151,6 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
     assert(enumVector(v).through(dropWhileM(i => F.pure(i < n.toInt))).toVector === F.pure(v.lastOption.toVector))
   }
 
-  /**
-   * We skip this test on Scala 2.10 because of weird "Bad invokespecial instruction" exceptions
-   * that I wasn't able to reproduce in other contexts.
-   */
-  //"collect" should "filter the stream using a partial function" taggedAs(NoScala210Test) in {
   "collect" should "filter the stream using a partial function" in {
     forAll { (eav: EnumeratorAndValues[Int]) =>
       val pf: PartialFunction[Int, Int] = {

--- a/testing/shared/src/main/scala/io/iteratee/testing/EnumerateeSuite.scala
+++ b/testing/shared/src/main/scala/io/iteratee/testing/EnumerateeSuite.scala
@@ -1,9 +1,10 @@
-package io.iteratee.tests
+package io.iteratee.testing
 
 import cats.Monad
 import cats.laws.discipline.{ CategoryTests, ProfunctorTests }
 import io.iteratee.{ Enumeratee, EnumerateeModule, EnumeratorModule, Iteratee, IterateeModule, Module }
 import org.scalacheck.{ Arbitrary, Gen }
+import scala.Predef._
 
 abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
   this: Module[F] with EnumerateeModule[F] with EnumeratorModule[F] with IterateeModule[F] =>
@@ -154,7 +155,8 @@ abstract class EnumerateeSuite[F[_]: Monad] extends ModuleSuite[F] {
    * We skip this test on Scala 2.10 because of weird "Bad invokespecial instruction" exceptions
    * that I wasn't able to reproduce in other contexts.
    */
-  "collect" should "filter the stream using a partial function" taggedAs(NoScala210Test) in {
+  //"collect" should "filter the stream using a partial function" taggedAs(NoScala210Test) in {
+  "collect" should "filter the stream using a partial function" in {
     forAll { (eav: EnumeratorAndValues[Int]) =>
       val pf: PartialFunction[Int, Int] = {
         case v if v % 2 == 0 => v + 1

--- a/testing/shared/src/main/scala/io/iteratee/testing/EnumeratorSuite.scala
+++ b/testing/shared/src/main/scala/io/iteratee/testing/EnumeratorSuite.scala
@@ -1,9 +1,10 @@
-package io.iteratee.tests
+package io.iteratee.testing
 
 import cats.{ Eq, Eval, Monad }
 import cats.kernel.laws.GroupLaws
 import cats.laws.discipline.{ CartesianTests, MonadTests }
 import io.iteratee.{ EnumerateeModule, Enumerator, EnumeratorModule, IterateeModule, Module }
+import scala.Predef._
 
 abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
     this: Module[F] with EnumerateeModule[F] with EnumeratorModule[F] with IterateeModule[F] =>

--- a/testing/shared/src/main/scala/io/iteratee/testing/EqInstances.scala
+++ b/testing/shared/src/main/scala/io/iteratee/testing/EqInstances.scala
@@ -1,17 +1,19 @@
-package io.iteratee.tests
+package io.iteratee.testing
 
-import cats.{ Eq, Monad }
+import cats.Monad
+import cats.kernel.Eq
 import io.iteratee.{ Enumeratee, Enumerator, Iteratee }
 import org.scalacheck.Arbitrary
+import scala.Predef._
 
 trait EqInstances {
-  implicit val eqThrowable: Eq[Throwable] = Eq.fromUniversalEquals
+  implicit def eqThrowable: Eq[Throwable] = Eq.fromUniversalEquals
 
   implicit def eqEnumerator[F[_]: Monad, A: Eq](implicit eq: Eq[F[Vector[A]]]): Eq[Enumerator[F, A]] =
     eq.on[Enumerator[F, A]](_.toVector)
 
   implicit def eqIteratee[F[_]: Monad, A: Eq: Arbitrary, B: Eq: Arbitrary](implicit
-    eq: Eq[F[B]]
+    eqFB: Eq[F[B]]
   ): Eq[Iteratee[F, A, B]] = {
     val e0 = Enumerator.empty[F, A]
     val e1 = Enumerator.enumList[F, A](Arbitrary.arbitrary[List[A]].sample.get)
@@ -19,15 +21,15 @@ trait EqInstances {
     val e3 = Enumerator.enumVector[F, A](Arbitrary.arbitrary[Vector[A]].sample.get)
 
     Eq.instance { (i, j) =>
-      eq.eqv(e0.into(i), e0.into(j)) &&
-      eq.eqv(e1.into(i), e1.into(j)) &&
-      eq.eqv(e2.into(i), e2.into(j)) &&
-      eq.eqv(e3.into(i), e3.into(j))
+      eqFB.eqv(e0.into(i), e0.into(j)) &&
+      eqFB.eqv(e1.into(i), e1.into(j)) &&
+      eqFB.eqv(e2.into(i), e2.into(j)) &&
+      eqFB.eqv(e3.into(i), e3.into(j))
     }
   }
 
   implicit def eqEnumeratee[F[_]: Monad, A: Eq: Arbitrary, B: Eq: Arbitrary](implicit
-    eq: Eq[F[Vector[B]]]
+    eqFVB: Eq[F[Vector[B]]]
   ): Eq[Enumeratee[F, A, B]] = {
     val e0 = Enumerator.empty[F, A]
     val e1 = Enumerator.enumList[F, A](Arbitrary.arbitrary[List[A]].sample.get)
@@ -35,10 +37,12 @@ trait EqInstances {
     val e3 = Enumerator.enumVector[F, A](Arbitrary.arbitrary[Vector[A]].sample.get)
 
     Eq.instance { (i, j) =>
-      eq.eqv(e0.through(i).toVector, e0.through(j).toVector) &&
-      eq.eqv(e1.through(i).toVector, e1.through(j).toVector) &&
-      eq.eqv(e2.through(i).toVector, e2.through(j).toVector) &&
-      eq.eqv(e3.through(i).toVector, e3.through(j).toVector)
+      eqFVB.eqv(e0.through(i).toVector, e0.through(j).toVector) &&
+      eqFVB.eqv(e1.through(i).toVector, e1.through(j).toVector) &&
+      eqFVB.eqv(e2.through(i).toVector, e2.through(j).toVector) &&
+      eqFVB.eqv(e3.through(i).toVector, e3.through(j).toVector)
     }
   }
 }
+
+object EqInstances extends EqInstances

--- a/testing/shared/src/main/scala/io/iteratee/testing/IterateeSuite.scala
+++ b/testing/shared/src/main/scala/io/iteratee/testing/IterateeSuite.scala
@@ -1,4 +1,4 @@
-package io.iteratee.tests
+package io.iteratee.testing
 
 import cats.{ Eq, Eval, Monad, MonadError }
 import cats.data.{ EitherT, NonEmptyList }
@@ -13,6 +13,7 @@ import io.iteratee.{
 }
 import io.iteratee.internal.Step
 import org.scalacheck.{ Arbitrary, Cogen }
+import scala.Predef._
 
 abstract class IterateeSuite[F[_]: Monad] extends BaseIterateeSuite[F] {
   this: EnumerateeModule[F] with EnumeratorModule[F] with IterateeModule[F] with Module[F] =>

--- a/tests/jvm/src/it/scala/io/iteratee/files/EitherFileModuleTests.scala
+++ b/tests/jvm/src/it/scala/io/iteratee/files/EitherFileModuleTests.scala
@@ -1,8 +1,8 @@
 package io.iteratee.files
 
 import cats.instances.either._
+import io.iteratee.testing.files.FileModuleSuite
 import io.iteratee.tests.EitherSuite
-import io.iteratee.tests.files.FileModuleSuite
 
 class EitherFileModuleTests extends FileModuleSuite[({ type L[x] = Either[Throwable, x] })#L] with EitherSuite
     with EitherFileModule

--- a/tests/jvm/src/it/scala/io/iteratee/files/EitherTFileModuleTests.scala
+++ b/tests/jvm/src/it/scala/io/iteratee/files/EitherTFileModuleTests.scala
@@ -2,8 +2,8 @@ package io.iteratee.files
 
 import cats.Eval
 import cats.data.EitherT
+import io.iteratee.testing.files.FileModuleSuite
 import io.iteratee.tests.EitherTSuite
-import io.iteratee.tests.files.FileModuleSuite
 
 class EitherTFileModuleTests extends FileModuleSuite[({ type L[x] = EitherT[Eval, Throwable, x] })#L]
     with EitherTSuite with EitherTFileModule

--- a/tests/jvm/src/it/scala/io/iteratee/files/FutureFileModuleTests.scala
+++ b/tests/jvm/src/it/scala/io/iteratee/files/FutureFileModuleTests.scala
@@ -1,8 +1,8 @@
 package io.iteratee.files
 
 import cats.instances.future._
+import io.iteratee.testing.files.FileModuleSuite
 import io.iteratee.tests.FutureSuite
-import io.iteratee.tests.files.FileModuleSuite
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 

--- a/tests/jvm/src/it/scala/io/iteratee/files/NonSuspendableFileModuleSuite.scala
+++ b/tests/jvm/src/it/scala/io/iteratee/files/NonSuspendableFileModuleSuite.scala
@@ -1,7 +1,7 @@
 package io.iteratee.files
 
 import io.iteratee.{ Iteratee, Enumerator }
-import io.iteratee.tests.BaseSuite
+import io.iteratee.testing.BaseSuite
 import scala.util.{ Success, Try }
 import java.io.File
 

--- a/tests/jvm/src/it/scala/io/iteratee/files/TryFileModuleTests.scala
+++ b/tests/jvm/src/it/scala/io/iteratee/files/TryFileModuleTests.scala
@@ -1,8 +1,8 @@
 package io.iteratee.files
 
 import cats.instances.try_._
+import io.iteratee.testing.files.FileModuleSuite
 import io.iteratee.tests.TrySuite
-import io.iteratee.tests.files.FileModuleSuite
 import scala.util.Try
 
 class TryFileModuleTests extends FileModuleSuite[Try] with TrySuite with TryFileModule

--- a/tests/jvm/src/test/scala/io/iteratee/FutureTests.scala
+++ b/tests/jvm/src/test/scala/io/iteratee/FutureTests.scala
@@ -2,9 +2,10 @@ package io.iteratee
 
 import cats.instances.future._
 import cats.laws.discipline.arbitrary.catsLawsCogenForThrowable
-import io.iteratee.tests.{ EnumerateeSuite, FutureSuite, IterateeErrorSuite, StackSafeEnumeratorSuite }
+import io.iteratee.testing.{ EnumerateeSuite, IterateeErrorSuite, StackSafeEnumeratorSuite }
+import io.iteratee.testing.EqInstances.eqThrowable
+import io.iteratee.tests.FutureSuite
 import io.iteratee.tests.FutureSuite.arbitraryNonFatalThrowable
-import io.iteratee.tests.eqThrowable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 

--- a/tests/shared/src/main/scala/io/iteratee/tests/package.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/package.scala
@@ -1,7 +1,0 @@
-package io.iteratee
-
-import org.scalatest.Tag
-
-package tests {
-  object NoScala210Test extends Tag("io.iteratee.tests.NoScala210Test")
-}

--- a/tests/shared/src/main/scala/io/iteratee/tests/package.scala
+++ b/tests/shared/src/main/scala/io/iteratee/tests/package.scala
@@ -1,12 +1,7 @@
 package io.iteratee
 
-import cats.Eq
 import org.scalatest.Tag
 
 package tests {
   object NoScala210Test extends Tag("io.iteratee.tests.NoScala210Test")
-}
-
-package object tests {
-  implicit val eqThrowable: Eq[Throwable] = Eq.fromUniversalEquals
 }

--- a/tests/shared/src/test/scala/io/iteratee/EitherTTests.scala
+++ b/tests/shared/src/test/scala/io/iteratee/EitherTTests.scala
@@ -4,7 +4,9 @@ import cats.{ Eval, Id, MonadError }
 import cats.arrow.FunctionK
 import cats.data.EitherT
 import cats.laws.discipline.arbitrary.catsLawsCogenForThrowable
-import io.iteratee.tests.{ EnumerateeSuite, StackSafeEnumeratorSuite, IterateeErrorSuite, EitherTSuite, eqThrowable }
+import io.iteratee.testing.{ EnumerateeSuite, IterateeErrorSuite, StackSafeEnumeratorSuite }
+import io.iteratee.testing.EqInstances.eqThrowable
+import io.iteratee.tests.EitherTSuite
 import org.scalacheck.Arbitrary
 
 class EitherTEnumerateeTests extends EnumerateeSuite[({ type L[x] = EitherT[Eval, Throwable, x] })#L]

--- a/tests/shared/src/test/scala/io/iteratee/EitherTests.scala
+++ b/tests/shared/src/test/scala/io/iteratee/EitherTests.scala
@@ -2,7 +2,9 @@ package io.iteratee
 
 import cats.instances.either._
 import cats.laws.discipline.arbitrary.catsLawsCogenForThrowable
-import io.iteratee.tests.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, EitherSuite, eqThrowable }
+import io.iteratee.testing.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite }
+import io.iteratee.testing.EqInstances.eqThrowable
+import io.iteratee.tests.EitherSuite
 
 class EitherEnumerateeTests extends EnumerateeSuite[({ type L[x] = Either[Throwable, x] })#L] with EitherSuite
 class EitherEnumeratorTests extends EnumeratorSuite[({ type L[x] = Either[Throwable, x] })#L] with EitherSuite

--- a/tests/shared/src/test/scala/io/iteratee/EvalTests.scala
+++ b/tests/shared/src/test/scala/io/iteratee/EvalTests.scala
@@ -1,7 +1,8 @@
 package io.iteratee
 
 import cats.Eval
-import io.iteratee.tests.{ EvalSuite, EnumerateeSuite, StackSafeEnumeratorSuite, IterateeSuite }
+import io.iteratee.testing.{ EnumerateeSuite, IterateeSuite, StackSafeEnumeratorSuite }
+import io.iteratee.tests.EvalSuite
 
 class EvalEnumerateeTests extends EnumerateeSuite[Eval] with EvalSuite
 

--- a/tests/shared/src/test/scala/io/iteratee/IdTests.scala
+++ b/tests/shared/src/test/scala/io/iteratee/IdTests.scala
@@ -1,7 +1,8 @@
 package io.iteratee
 
 import cats.Id
-import io.iteratee.tests.{ EnumerateeSuite, EnumeratorSuite, IdSuite, IterateeSuite }
+import io.iteratee.testing.{ EnumerateeSuite, EnumeratorSuite, IterateeSuite }
+import io.iteratee.tests.IdSuite
 
 class IdEnumerateeTests extends EnumerateeSuite[Id] with IdSuite
 class IdEnumeratorTests extends EnumeratorSuite[Id] with IdSuite

--- a/tests/shared/src/test/scala/io/iteratee/OptionTests.scala
+++ b/tests/shared/src/test/scala/io/iteratee/OptionTests.scala
@@ -1,7 +1,8 @@
 package io.iteratee
 
 import cats.instances.option._
-import io.iteratee.tests.{ EnumerateeSuite, EnumeratorSuite, OptionSuite, IterateeSuite }
+import io.iteratee.testing.{ EnumerateeSuite, EnumeratorSuite, IterateeSuite }
+import io.iteratee.tests.OptionSuite
 
 class OptionEnumerateeTests extends EnumerateeSuite[Option] with OptionSuite
 class OptionEnumeratorTests extends EnumeratorSuite[Option] with OptionSuite

--- a/tests/shared/src/test/scala/io/iteratee/TryTests.scala
+++ b/tests/shared/src/test/scala/io/iteratee/TryTests.scala
@@ -2,7 +2,9 @@ package io.iteratee
 
 import cats.instances.try_._
 import cats.laws.discipline.arbitrary.catsLawsCogenForThrowable
-import io.iteratee.tests.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, TrySuite, eqThrowable }
+import io.iteratee.testing.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite }
+import io.iteratee.testing.EqInstances.eqThrowable
+import io.iteratee.tests.TrySuite
 import scala.util.Try
 
 class TryEnumerateeTests extends EnumerateeSuite[Try] with TrySuite

--- a/twitter/src/it/scala/io/iteratee/twitter/FutureFileModuleTests.scala
+++ b/twitter/src/it/scala/io/iteratee/twitter/FutureFileModuleTests.scala
@@ -4,7 +4,7 @@ import cats.Eq
 import com.twitter.conversions.time._
 import com.twitter.util.Future
 import io.catbird.util.{ futureEqWithFailure, twitterFutureInstance }
-import io.iteratee.tests.files.FileModuleSuite
+import io.iteratee.testing.files.FileModuleSuite
 
 class FutureFileModuleTests extends FileModuleSuite[Future] with FutureModule {
   def monadName: String = "Future"

--- a/twitter/src/it/scala/io/iteratee/twitter/RerunnableFileModuleTests.scala
+++ b/twitter/src/it/scala/io/iteratee/twitter/RerunnableFileModuleTests.scala
@@ -3,7 +3,7 @@ package io.iteratee.twitter
 import cats.Eq
 import com.twitter.conversions.time._
 import io.catbird.util.Rerunnable
-import io.iteratee.tests.files.FileModuleSuite
+import io.iteratee.testing.files.FileModuleSuite
 
 class RerunnableFileModuleTests extends FileModuleSuite[Rerunnable] with RerunnableModule {
   def monadName: String = "Rerunnable"

--- a/twitter/src/it/scala/io/iteratee/twitter/TryFileModuleTests.scala
+++ b/twitter/src/it/scala/io/iteratee/twitter/TryFileModuleTests.scala
@@ -3,7 +3,7 @@ package io.iteratee.twitter
 import cats.Eq
 import com.twitter.util.Try
 import io.catbird.util.{ twitterTryEq, twitterTryInstance }
-import io.iteratee.tests.files.FileModuleSuite
+import io.iteratee.testing.files.FileModuleSuite
 
 class TryFileModuleTests extends FileModuleSuite[Try] with TryModule {
   def monadName: String = "Try"

--- a/twitter/src/test/scala/io/iteratee/twitter/FutureTests.scala
+++ b/twitter/src/test/scala/io/iteratee/twitter/FutureTests.scala
@@ -5,7 +5,8 @@ import cats.laws.discipline.arbitrary.catsLawsCogenForThrowable
 import com.twitter.conversions.time._
 import com.twitter.util.Future
 import io.catbird.util.{ futureEqWithFailure, twitterFutureInstance }
-import io.iteratee.tests.{ EnumerateeSuite, IterateeErrorSuite, ModuleSuite, StackSafeEnumeratorSuite, eqThrowable }
+import io.iteratee.testing.{ EnumerateeSuite, IterateeErrorSuite, ModuleSuite, StackSafeEnumeratorSuite }
+import io.iteratee.testing.EqInstances.eqThrowable
 
 trait FutureSuite extends ModuleSuite[Future] with FutureModule {
   def monadName: String = "com.twitter.util.Future"

--- a/twitter/src/test/scala/io/iteratee/twitter/RerunnableTests.scala
+++ b/twitter/src/test/scala/io/iteratee/twitter/RerunnableTests.scala
@@ -4,7 +4,8 @@ import cats.Eq
 import cats.laws.discipline.arbitrary.catsLawsCogenForThrowable
 import com.twitter.conversions.time._
 import io.catbird.util.Rerunnable
-import io.iteratee.tests.{ EnumerateeSuite, IterateeErrorSuite, ModuleSuite, StackSafeEnumeratorSuite, eqThrowable }
+import io.iteratee.testing.{ EnumerateeSuite, IterateeErrorSuite, ModuleSuite, StackSafeEnumeratorSuite }
+import io.iteratee.testing.EqInstances.eqThrowable
 
 trait RerunnableSuite extends ModuleSuite[Rerunnable] with RerunnableModule {
   def monadName: String = "Rerunnable"

--- a/twitter/src/test/scala/io/iteratee/twitter/TryTests.scala
+++ b/twitter/src/test/scala/io/iteratee/twitter/TryTests.scala
@@ -4,7 +4,8 @@ import cats.Eq
 import cats.laws.discipline.arbitrary.catsLawsCogenForThrowable
 import com.twitter.util.Try
 import io.catbird.util.{ twitterTryEq, twitterTryInstance }
-import io.iteratee.tests.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, ModuleSuite, eqThrowable }
+import io.iteratee.testing.{ EnumerateeSuite, EnumeratorSuite, IterateeErrorSuite, ModuleSuite }
+import io.iteratee.testing.EqInstances.eqThrowable
 
 trait TrySuite extends ModuleSuite[Try] with TryModule {
   def monadName: String = "com.twitter.util.Try"


### PR DESCRIPTION
This abstracts out some of our testing code into its own (publishable) module, which will allow us to more easily split modules into their own repositories so that they can be versioned independently, etc.

There are a few things I might still end up wanting to rearrange here, but this I think is a reasonable first pass.