### PR TITLE
Dependency upgrades

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,10 +18,10 @@ lazy val compilerOptions = Seq(
   "-Xfuture"
 )
 
-lazy val catsVersion = "1.0.0-RC1"
+lazy val catsVersion = "1.0.0-RC2"
 lazy val disciplineVersion = "0.8"
-lazy val monixVersion = "2.3.0"
-lazy val fs2Version = "0.10.0-M8"
+lazy val monixVersion = "2.3.2"
+lazy val fs2Version = "0.10.0-M9"
 
 lazy val scalaCheckVersion = "1.13.5"
 lazy val scalaTestVersion = "3.0.4"
@@ -57,7 +57,7 @@ lazy val baseSettings = Seq(
     }
   ),
   (scalastyleSources in Compile) ++= (sourceDirectories in Compile).value,
-  addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.4" cross CrossVersion.binary)
+  addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.5" cross CrossVersion.binary)
 )
 
 lazy val allSettings = baseSettings ++ publishSettings

--- a/testing/shared/src/main/scala/io/iteratee/testing/IterateeSuite.scala
+++ b/testing/shared/src/main/scala/io/iteratee/testing/IterateeSuite.scala
@@ -61,7 +61,7 @@ abstract class IterateeErrorSuite[F[_], T: Arbitrary: Eq: Cogen](implicit
   "ensureEval" should "be executed when the iteratee is done" in forAll { (eav: EnumeratorAndValues[Int]) =>
     var done = false
 
-    val iteratee = consume[Int].ensureEval(Eval.always(F.pure(done = true)))
+    val iteratee = consume[Int].ensureEval(Eval.always(F.pure { done = true }))
 
     assert(!done)
     assert(eav.resultWithLeftovers(iteratee) === F.pure((eav.values, Vector.empty)))


### PR DESCRIPTION
Builds for cats-1.0.0-RC2.  If this gets released, we can keep validating more projects downstream without reasoning about eviction.

If this doesn't get released, can bump again next week to cats-1.0.0.