### PR TITLE
Cats 1.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val compilerOptions = Seq(
   "-Xfuture"
 )
 
-lazy val catsVersion = "1.0.0-RC2"
+lazy val catsVersion = "1.0.0"
 lazy val disciplineVersion = "0.8"
 lazy val monixVersion = "2.3.2"
 lazy val fs2Version = "0.10.0-M10"

--- a/build.sbt
+++ b/build.sbt
@@ -176,7 +176,7 @@ lazy val scalaz = project
   )
   .settings(allSettings ++ Defaults.itSettings)
   .settings(
-    libraryDependencies += "org.scalaz" %% "scalaz-concurrent" % "7.2.17"
+    libraryDependencies += "org.scalaz" %% "scalaz-concurrent" % "7.2.18"
   ).dependsOn(core, files, tests % "test,it")
 
 lazy val monixBase = crossModule("monix")
@@ -210,7 +210,7 @@ lazy val benchmark = project
     libraryDependencies ++= Seq(
       "co.fs2" %% "fs2-core" % fs2Version,
       "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
-      "org.scalaz" %% "scalaz-iteratee" % "7.2.16",
+      "org.scalaz" %% "scalaz-iteratee" % "7.2.18",
       "org.scalaz.stream" %% "scalaz-stream" % "0.8.6a",
       "org.typelevel" %% "cats-free" % catsVersion
     )


### PR DESCRIPTION
There's still no fs2 release for Cats 1.0.0, but we only need it for the benchmarks here, so it's not a big deal.