### PR TITLE
Make Enumerator monad laws pass (tailRecM)

### DIFF
--- a/core/src/main/scala/io/iteratee/Enumeratee.scala
+++ b/core/src/main/scala/io/iteratee/Enumeratee.scala
@@ -82,33 +82,33 @@ final object Enumeratee {
       }
     }
 
-  final def tailRecM[F[_], A, B](f: A => Enumerator[F, Either[A, B]])(implicit F: Monad[F]): Enumeratee[F, Either[A, B], B] =
+  final def tailRecM[F[_], A, B](
+    f: A => Enumerator[F, Either[A, B]]
+  )(implicit F: Monad[F]): Enumeratee[F, Either[A, B], B] =
     new PureLoop[F, Either[A, B], B] {
       protected final def loop[C](step: Step[F, B, C]): Step[F, Either[A, B], Step[F, B, C]] =
         new StepCont[F, Either[A, B], B, C](step) {
           @annotation.tailrec
-          final def feedEl(e: Either[A, B]): F[Step[F, Either[A, B], Step[F, B, C]]] = {
+          final def feedEl(e: Either[A, B]): F[Step[F, Either[A, B], Step[F, B, C]]] =
             e match {
               case Left(a) =>
                 f(a) match {
                   case Enumerator.EnumOne(e, _) => feedEl(e)
-                  case other => other(this)
+                  case other                    => other(this)
                 }
               case Right(b) =>
                 F.map(step.feedEl(b))(doneOrLoop)
             }
-          }
           final protected def feedNonEmpty(chunk: Seq[Either[A, B]]): F[Step[F, Either[A, B], Step[F, B, C]]] = {
             val enumerator = chunk.iterator.map {
               case Left(a) => f(a)
-              case right => Enumerator.enumOne[F, Either[A, B]](right)
-            }
-            .reduce(_.append(_))
+              case right   => Enumerator.enumOne[F, Either[A, B]](right)
+            }.reduce(_.append(_))
 
             enumerator(this)
           }
         }
-      }
+    }
 
   /**
    * An [[Enumeratee]] that takes a given number of the first values in a

--- a/core/src/main/scala/io/iteratee/Enumerator.scala
+++ b/core/src/main/scala/io/iteratee/Enumerator.scala
@@ -116,7 +116,7 @@ final object Enumerator {
       def loop(fn: () => Enumerator[F, E]): Enumerator[F, E] =
         fn() match {
           case DeferEnumerator(nextFn) => loop(nextFn)
-          case notDefer => notDefer
+          case notDefer                => notDefer
         }
       loop(build)
     }
@@ -138,10 +138,6 @@ final object Enumerator {
       final override def map[A, B](fa: Enumerator[F, A])(f: A => B): Enumerator[F, B] = fa.map(f)
       final def flatMap[A, B](fa: Enumerator[F, A])(f: A => Enumerator[F, B]): Enumerator[F, B] = fa.flatMap(f)
       final def pure[E](e: E): Enumerator[F, E] = Enumerator.enumOne[F, E](e)
-
-      /**
-       * Note that recursive monadic binding is not stack safe for enumerators.
-       */
       final def tailRecM[A, B](a: A)(f: A => Enumerator[F, Either[A, B]]): Enumerator[F, B] =
         f(a).through(Enumeratee.tailRecM(f))
     }
@@ -194,6 +190,7 @@ final object Enumerator {
   private[iteratee] case class EnumOne[F[_], E](e: E, app: Applicative[F]) extends Enumerator[F, E] {
     final def apply[A](s: Step[F, E, A]): F[Step[F, E, A]] = s.feedEl(e)
   }
+
   /**
    * An enumerator that produces a single value.
    */

--- a/testing/shared/src/main/scala/io/iteratee/testing/EnumeratorSuite.scala
+++ b/testing/shared/src/main/scala/io/iteratee/testing/EnumeratorSuite.scala
@@ -16,7 +16,7 @@ abstract class EnumeratorSuite[F[_]: Monad] extends ModuleSuite[F] {
     SemigroupalTests.Isomorphisms.invariant[EnumeratorF]
 
   checkLaws(s"Enumerator[$monadName, Int]", MonoidTests[Enumerator[F, Int]].monoid)
-  checkLaws(s"Enumerator[$monadName, Int]", MonadTests[EnumeratorF].stackUnsafeMonad[Int, Int, Int])
+  checkLaws(s"Enumerator[$monadName, Int]", MonadTests[EnumeratorF].monad[Int, Int, Int])
 
   "liftToEnumerator" should "lift a value in a context into an enumerator" in forAll { (i: Int) =>
     assert(liftToEnumerator(F.pure(i)).toVector === F.pure(Vector(i)))


### PR DESCRIPTION
close #158 

This was a bit of a pain in the ass due to the layers in this set of abstractions. There is likely a somewhat better way to do this, but at least the tests pass.